### PR TITLE
SPモードの軽量化と操作不具合の修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,11 +22,12 @@ export default function RootLayout({
       <body
         className={`relative antialiased h-screen select-none overflow-x-hidden overflow-y-hidden`}
       >
-        {/* Image を使用してしまうと読み込みが狂ったため img を使用 */}
+        {/* SP はカードが全面を覆うため背景画像を読み込まない（~800KB 削減） */}
         <img
           src="/okumono_moku14.png"
-          alt="background"
-          className="absolute h-full w-full z-[-10] object-cover"
+          alt=""
+          className="absolute h-full w-full z-[-10] object-cover hidden min-[500px]:block"
+          decoding="async"
         />
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,21 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Grid from "../components/Grid";
-import GridSP from "../components/GridSP";
+import dynamic from "next/dynamic";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
-export default function App() {
-  const [isSP, setIsSP] = useState(true); // スマホ判定
+const Grid = dynamic(() => import("../components/Grid"), {
+  ssr: false,
+  loading: () => <div className="w-full h-dvh" />,
+});
+const GridSP = dynamic(() => import("../components/GridSP"), {
+  ssr: false,
+  loading: () => <div className="w-full h-dvh" />,
+});
 
-  // 画面幅が 500px 以上の場合は false にする
+export default function App() {
+  const [isSP, setIsSP] = useState<boolean | null>(null);
+
   useEffect(() => {
     const handleResize = () => {
       setIsSP(window.innerWidth < 500);
@@ -16,13 +23,14 @@ export default function App() {
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []); // 初回のみ実行
+  }, []);
 
   return (
     <div className="w-full h-full">
-      {/* SPモードの切り替え */}
       <ErrorBoundary>
-        {isSP ? (
+        {isSP === null ? (
+          <div className="w-full h-dvh" />
+        ) : isSP ? (
           <GridSP />
         ) : (
           <Grid />

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -62,14 +62,19 @@ export default function Grid() {
     const cardListStorage = getLocalStorage("cardList");
     const cardStyleStorage = getLocalStorage("cardStyle");
     const playersStorage = getLocalStorage("players");
-    setCardList(cardListStorage ? JSON.parse(cardListStorage) : initialCardsList);
+    // SP 保存分に setter が無い場合もあるため、空きマスを setter で埋めてから使う
+    setCardList(
+      cardListStorage
+        ? setInitialCardsList(JSON.parse(cardListStorage), maxRange.rows, maxRange.cols)
+        : initialCardsListFilled
+    );
     setCardStyle(cardStyleStorage ? JSON.parse(cardStyleStorage) : initialStyle);
     setPlayers(playersStorage ? JSON.parse(playersStorage) : initialPlayers);
   }, []);
 
   // カードリスト変更、カードスタイル変更をローカルストレージに保存する useEffect
   useEffect(() => {
-    if (cardList === initialCardsList) return;
+    if (cardList === initialCardsListFilled) return;
     setLocalStorage("cardList", JSON.stringify(cardList));
   }, [cardList]);
   useEffect(() => {

--- a/components/GridSP.tsx
+++ b/components/GridSP.tsx
@@ -11,7 +11,6 @@ const swipeEffectThreshold = 50; // スワイプの遊び閾値
 
 type CardContentProps = {
   card: CardSetting;
-  index: number;
   isActive: boolean;
   zoomRatio: number;
   players: Player[];
@@ -266,7 +265,6 @@ export default function GridSP() {
         >
           <CardContent
             card={card}
-            index={index}
             isActive={isActive}
             zoomRatio={zoomRatio}
             players={players}

--- a/components/GridSP.tsx
+++ b/components/GridSP.tsx
@@ -154,11 +154,19 @@ export default function GridSP() {
     const touchEnd = touchEndRef.current;
     if (!touchStart || !touchEnd || isAnimatingRef.current) return;
 
-    setIsAnimating(true);
-    isAnimatingRef.current = true;
-
     const deltaX = touchEnd.x - touchStart.x;
     const width = window.innerWidth;
+
+    // タップ（閾値未満）はスワイプ処理しない → 3D の pointer イベントを邪魔しない
+    if (Math.abs(deltaX) < cardTransitionThreshold) {
+      setSwipeOffset(0);
+      touchStartRef.current = null;
+      touchEndRef.current = null;
+      return;
+    }
+
+    setIsAnimating(true);
+    isAnimatingRef.current = true;
 
     if (deltaX > cardTransitionThreshold) {
       setSwipeOffset(width * 0.3);
@@ -170,17 +178,11 @@ export default function GridSP() {
         setIsAnimating(false);
         isAnimatingRef.current = false;
       }, 100);
-    } else if (deltaX < -cardTransitionThreshold) {
+    } else {
       setSwipeOffset(-width * 0.3);
       setTimeout(() => {
         setCurrentIndex((prevIndex) => (prevIndex + 1) % cardListRef.current.length);
         setSwipeOffset(0);
-        setIsAnimating(false);
-        isAnimatingRef.current = false;
-      }, 100);
-    } else {
-      setSwipeOffset(0);
-      setTimeout(() => {
         setIsAnimating(false);
         isAnimatingRef.current = false;
       }, 100);

--- a/components/GridSP.tsx
+++ b/components/GridSP.tsx
@@ -1,52 +1,103 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo, memo } from "react";
 import { cardMap, initialCardsList, initialStyle, initialPlayers, fonts } from "../utils/cardDefinitions";
 import { getLocalStorage, setLocalStorage } from "../utils/localFuncs";
 import { calculateAndUpdateGrid } from "@/utils/cardFuncs";
+import type { CardSetting, CardStyle, Player } from "@/utils/types";
 
 const cardTransitionThreshold = 80; // スワイプの閾値
 const swipeEffectThreshold = 50; // スワイプの遊び閾値
+
+type CardContentProps = {
+  card: CardSetting;
+  index: number;
+  isActive: boolean;
+  zoomRatio: number;
+  players: Player[];
+  setPlayers: (players: Player[]) => void;
+  cardStyle: CardStyle;
+  setCardStyle: (style: CardStyle) => void;
+  setCardList: (list: CardSetting[]) => void;
+  bgColor: string;
+  fontColor: string;
+};
+
+/** スワイプ中も再レンダーされないカード本体 */
+const CardContent = memo(function CardContent({
+  card,
+  isActive,
+  zoomRatio,
+  players,
+  setPlayers,
+  cardStyle,
+  setCardStyle,
+  setCardList,
+  bgColor,
+  fontColor,
+}: CardContentProps) {
+  const Component = cardMap[card.component] || (() => <div>Component not found</div>);
+
+  return (
+    <div
+      className="w-full h-full"
+      style={{ backgroundColor: bgColor, color: fontColor }}
+    >
+      <div
+        className="absolute top-1/2 left-1/2 w-56 h-56 transform -translate-x-1/2 -translate-y-1/2"
+        style={{ zoom: zoomRatio }}
+      >
+        <Component
+          zoomRatio={zoomRatio}
+          players={players}
+          setPlayers={setPlayers}
+          cardStyle={cardStyle}
+          setCardStyle={setCardStyle}
+          setCardList={setCardList}
+          isActive={isActive}
+        />
+      </div>
+    </div>
+  );
+});
 
 export default function GridSP() {
   // ======================================================================
   // ステート定義
   // ======================================================================
-  const [cardList, setCardList] = useState(initialCardsList); // カードリスト
-  const [cardStyle, setCardStyle] = useState(initialStyle); // スタイル設定
-  const [players, setPlayers] = useState(initialPlayers); // プレイヤーデータ
-  const [zoomRatio, setZoomRatio] = useState(1); // ズーム倍率
-  const [currentIndex, setCurrentIndex] = useState(0); // 現在表示しているカードのインデックス
-  const [touchStart, setTouchStart] = useState<{ x: number, y: number } | null>(null); // タッチ開始位置
-  const [touchEnd, setTouchEnd] = useState<{ x: number, y: number } | null>(null); // タッチ終了位置
-  const [swipeOffset, setSwipeOffset] = useState(0); // スワイプのオフセット値
-  const [isAnimating, setIsAnimating] = useState(false); // アニメーション中かどうか
-  const [windowWidth, setWindowWidth] = useState(0); // ウィンドウの幅
+  const [cardList, setCardList] = useState(initialCardsList);
+  const [cardStyle, setCardStyle] = useState(initialStyle);
+  const [players, setPlayers] = useState(initialPlayers);
+  const [zoomRatio, setZoomRatio] = useState(1);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   const cardListRef = useRef(cardList);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
+  const touchEndRef = useRef<{ x: number; y: number } | null>(null);
+  const isAnimatingRef = useRef(false);
 
   useEffect(() => {
     cardListRef.current = cardList;
   }, [cardList]);
 
-  // クライアントサイドでのみ実行される useEffect
   useEffect(() => {
-    setWindowWidth(window.innerWidth);
-  }, []);
+    isAnimatingRef.current = isAnimating;
+  }, [isAnimating]);
 
-  // グリッドのズーム倍率を更新する useEffect
+  // グリッドのズーム倍率を更新
   useEffect(() => {
     const handleResize = () => {
       const { zoomRatio } = calculateAndUpdateGrid(window.outerWidth, window.innerWidth);
       setZoomRatio(zoomRatio);
-      setWindowWidth(window.innerWidth);
     };
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []); // 初回のみ実行
+  }, []);
 
-  // 一部プロパティをローカルストレージからステートへ読み込む useEffect
+  // ローカルストレージから読み込み
   useEffect(() => {
     const cardListStorage = getLocalStorage("cardList");
     const cardStyleStorage = getLocalStorage("cardStyle");
@@ -56,15 +107,15 @@ export default function GridSP() {
     setPlayers(playersStorage ? JSON.parse(playersStorage) : initialPlayers);
   }, []);
 
-  // カードリストに setter がふくまれている場合は取り除く
+  // setter カードを除去
   useEffect(() => {
-    const newCardList = cardList.filter(card => card.component !== "setter");
+    const newCardList = cardList.filter((card) => card.component !== "setter");
     if (newCardList.length !== cardList.length) {
       setCardList(newCardList);
     }
   }, [cardList]);
 
-  // カードリスト変更、カードスタイル変更をローカルストレージに保存する useEffect
+  // ローカルストレージへ保存
   useEffect(() => {
     if (cardList === initialCardsList) return;
     setLocalStorage("cardList", JSON.stringify(cardList));
@@ -74,164 +125,169 @@ export default function GridSP() {
     setLocalStorage("cardStyle", JSON.stringify(cardStyle));
   }, [cardStyle]);
 
-  // スワイプハンドラ
-  const handleTouchStart = (e: React.TouchEvent) => {
-    if (isAnimating) return;
+  // スワイプハンドラ（タッチ座標は ref で持ち、再レンダーを抑制）
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (isAnimatingRef.current) return;
     const touch = e.touches[0];
-    setTouchStart({ x: touch.clientX, y: touch.clientY });
-    setTouchEnd({ x: touch.clientX, y: touch.clientY });
+    touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+    touchEndRef.current = { x: touch.clientX, y: touch.clientY };
     setSwipeOffset(0);
-  };
+  }, []);
 
-  const handleTouchMove = (e: React.TouchEvent) => {
-    if (!touchStart || isAnimating) return;
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!touchStartRef.current || isAnimatingRef.current) return;
     const touch = e.touches[0];
-    setTouchEnd({ x: touch.clientX, y: touch.clientY });
-    const deltaX = touch.clientX - touchStart.x;
+    touchEndRef.current = { x: touch.clientX, y: touch.clientY };
+    const deltaX = touch.clientX - touchStartRef.current.x;
 
-    // スワイプの閾値を超えたところのみを実効値とする
     if (Math.abs(deltaX) < swipeEffectThreshold) {
       setSwipeOffset(0);
       return;
     }
     const effectiveDeltaX = (Math.abs(deltaX) - swipeEffectThreshold) * (deltaX > 0 ? 1 : -1);
-
-    // スワイプのオフセット値はスワイプした距離の2乗根をベースに計算
     const newOffset = Math.sqrt(Math.abs(effectiveDeltaX)) * 5 * (effectiveDeltaX > 0 ? 1 : -1);
     setSwipeOffset(newOffset);
-  };
+  }, []);
 
-  const handleTouchEnd = () => {
-    if (!touchStart || !touchEnd || isAnimating) return;
+  const handleTouchEnd = useCallback(() => {
+    const touchStart = touchStartRef.current;
+    const touchEnd = touchEndRef.current;
+    if (!touchStart || !touchEnd || isAnimatingRef.current) return;
+
     setIsAnimating(true);
+    isAnimatingRef.current = true;
 
     const deltaX = touchEnd.x - touchStart.x;
-    if (deltaX > cardTransitionThreshold) { // 右スワイプ
-      // アニメーションの終了を待つ
-      setSwipeOffset(windowWidth * 0.3);
+    const width = window.innerWidth;
+
+    if (deltaX > cardTransitionThreshold) {
+      setSwipeOffset(width * 0.3);
       setTimeout(() => {
-        setCurrentIndex((prevIndex) => (prevIndex - 1 + cardListRef.current.length) % cardListRef.current.length);
+        setCurrentIndex((prevIndex) =>
+          (prevIndex - 1 + cardListRef.current.length) % cardListRef.current.length
+        );
         setSwipeOffset(0);
         setIsAnimating(false);
+        isAnimatingRef.current = false;
       }, 100);
-    } else if (deltaX < -cardTransitionThreshold) { // 左スワイプ
-      setSwipeOffset(-windowWidth * 0.3);
+    } else if (deltaX < -cardTransitionThreshold) {
+      setSwipeOffset(-width * 0.3);
       setTimeout(() => {
         setCurrentIndex((prevIndex) => (prevIndex + 1) % cardListRef.current.length);
         setSwipeOffset(0);
         setIsAnimating(false);
+        isAnimatingRef.current = false;
       }, 100);
     } else {
-      // スワイプが閾値未満の場合、元の位置に戻す
       setSwipeOffset(0);
       setTimeout(() => {
         setIsAnimating(false);
+        isAnimatingRef.current = false;
       }, 100);
     }
 
-    setTouchStart(null);
-    setTouchEnd(null);
-  };
+    touchStartRef.current = null;
+    touchEndRef.current = null;
+  }, []);
 
-  // カードスタイルをメモ化して再計算を防止
-  const getCardStyle = useCallback((index: number) => {
-    const isEven = index % 2 === 0;
-    return {
-      backgroundColor: isEven ? cardStyle.bgColor_1 : cardStyle.bgColor_2,
-      color: isEven ? cardStyle.fontColor_1 : cardStyle.fontColor_2,
-    };
-  }, [cardStyle]);
+  const pageIndicator = useMemo(
+    () => (
+      <div className="absolute z-10 bottom-6 left-0 right-0 flex justify-center pointer-events-none">
+        {cardList.map((_, i) => (
+          <div
+            key={i}
+            className={`w-2 h-2 mx-1 rounded-full ${i === currentIndex ? "bg-white" : "bg-gray-400"}`}
+          />
+        ))}
+      </div>
+    ),
+    [cardList, currentIndex]
+  );
 
-  // ページインジケーターをメモ化
-  const pageIndicator = useMemo(() => (
-    <div className="absolute z-10 bottom-6 left-0 right-0 flex justify-center">
-      {cardList.map((_, i) => (
+  const cardColors = useMemo(() => {
+    return cardList.map((_, index) => {
+      const isEven = index % 2 === 0;
+      return {
+        bgColor: isEven ? cardStyle.bgColor_1 : cardStyle.bgColor_2,
+        fontColor: isEven ? cardStyle.fontColor_1 : cardStyle.fontColor_2,
+      };
+    });
+  }, [cardList, cardStyle]);
+
+  // 現在・前後カードのみ表示。本体は memo 化しているためスワイプ中はシェルだけ更新される
+  const cards = useMemo(() => {
+    const len = cardList.length;
+    if (len === 0) return null;
+
+    return cardList.map((card, index) => {
+      const positionDiff = index - currentIndex;
+      const normalizedPositionDiff = ((positionDiff % len) + len) % len;
+
+      let translateX = 0;
+      let zIndex = 0;
+      let visible = false;
+
+      if (normalizedPositionDiff === 0) {
+        translateX = swipeOffset;
+        zIndex = 2;
+        visible = true;
+      } else if (normalizedPositionDiff === len - 1) {
+        translateX = -100 + swipeOffset;
+        zIndex = 1;
+        visible = true;
+      } else if (normalizedPositionDiff === 1) {
+        translateX = 100 + swipeOffset;
+        zIndex = 1;
+        visible = true;
+      }
+
+      // 表示中カードのみ WebGL を起動（同時 Canvas を 1 つに抑える）
+      const isActive = normalizedPositionDiff === 0;
+
+      const colors = cardColors[index];
+
+      return (
         <div
-          key={i}
-          className={`w-2 h-2 mx-1 rounded-full ${i === currentIndex ? 'bg-white' : 'bg-gray-400'}`}
-        />
-      ))}
-    </div>
-  ), [cardList.length, currentIndex]);
-
-  // 各カードのコンポーネント（全カードを常にレンダリング）
-  const renderCard = useCallback((index: number) => {
-    const card = cardList[index];
-    const Component = cardMap[card.component] || (() => <div>Component not found</div>);
-
-    // 現在のカードに対する相対位置を計算
-    const positionDiff = index - currentIndex;
-    const normalizedPositionDiff = ((positionDiff + cardList.length) % cardList.length);
-
-    // 相対位置に基づいて表示位置を決定
-    // 現在のカード: 0, 前のカード: -1, 次のカード: 1, その他は非表示
-    let translateX = 0;
-    let zIndex = 0;
-    let opacity = 0;
-    let display = "none";
-
-    // 現在表示中のカード（現在、前、次）の位置と表示状態を設定
-    if (normalizedPositionDiff === 0) { // 現在のカード
-      translateX = swipeOffset;
-      zIndex = 2;
-      opacity = 1;
-      display = "block";
-    } else if (normalizedPositionDiff === cardList.length - 1 || normalizedPositionDiff === -1) { // 前のカード
-      translateX = -100 + swipeOffset;
-      zIndex = 1;
-      opacity = 1;
-      display = "block";
-    } else if (normalizedPositionDiff === 1) { // 次のカード
-      translateX = 100 + swipeOffset;
-      zIndex = 1;
-      opacity = 1;
-      display = "block";
-    }
-
-    // スワイプのオフセット値に基づいてぼかし効果を計算
-    const offsetPercent = (swipeOffset / windowWidth) * 100;
-    const blurAmount = normalizedPositionDiff === 0 ? Math.abs(offsetPercent) * 0.2 : 0;
-
-    return (
-      <div
-        key={index}
-        className="absolute w-full h-full text-center"
-        style={{
-          ...getCardStyle(index),
-          transform: `translateX(${translateX}%)`,
-          transition: isAnimating ? 'transform 0.3s ease-out, filter 0.3s ease-out' : 'none',
-          zIndex: zIndex,
-          opacity: opacity,
-          display: display, // 表示状態を制御
-          willChange: 'transform, opacity', // パフォーマンス最適化
-        }}
-      >
-        <div
-          className="w-full h-full"
+          key={`${card.component}-${index}`}
+          className="absolute w-full h-full text-center"
           style={{
-            filter: `blur(${blurAmount}px)`,
+            transform: `translate3d(${translateX}%, 0, 0)`,
+            transition: isAnimating ? "transform 0.1s ease-out" : "none",
+            zIndex,
+            // display:none だと再表示時のコストが大きいので、非表示は visibility + 画面外へ
+            visibility: visible ? "visible" : "hidden",
+            pointerEvents: visible ? "auto" : "none",
+            // 非表示カードはレイアウト計算を抑える
+            contentVisibility: visible ? "visible" : "hidden",
+            willChange: visible ? "transform" : "auto",
           }}
         >
-          <div
-            className="absolute top-1/2 left-1/2 w-56 h-56 transform -translate-x-1/2 -translate-y-1/2"
-            style={{
-              zoom: zoomRatio,
-            }}
-          >
-            {/* カードの中身 */}
-            <Component
-              zoomRatio={zoomRatio}
-              players={players}
-              setPlayers={setPlayers}
-              cardStyle={cardStyle}
-              setCardStyle={setCardStyle}
-              setCardList={setCardList}
-            />
-          </div>
+          <CardContent
+            card={card}
+            index={index}
+            isActive={isActive}
+            zoomRatio={zoomRatio}
+            players={players}
+            setPlayers={setPlayers}
+            cardStyle={cardStyle}
+            setCardStyle={setCardStyle}
+            setCardList={setCardList}
+            bgColor={colors.bgColor}
+            fontColor={colors.fontColor}
+          />
         </div>
-      </div>
-    );
-  }, [cardList, currentIndex, swipeOffset, isAnimating, windowWidth, zoomRatio, players, cardStyle, getCardStyle]);
+      );
+    });
+  }, [
+    cardList,
+    currentIndex,
+    swipeOffset,
+    isAnimating,
+    zoomRatio,
+    players,
+    cardStyle,
+    cardColors,
+  ]);
 
   return (
     <div
@@ -240,10 +296,7 @@ export default function GridSP() {
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
-      {/* すべてのカードを常にレンダリング */}
-      {cardList.map((_, index) => renderCard(index))}
-
-      {/* メモ化されたページインジケーター */}
+      {cards}
       {pageIndicator}
     </div>
   );

--- a/components/Setter.tsx
+++ b/components/Setter.tsx
@@ -13,8 +13,8 @@ export default function Setter(props: {
 }) {
   const { item, cardMap, cardList, setCardList, bgColor, fontColor } = props;
 
-  // カードの状態（表示なし、＋ボタン表示、コンポーネントリスト表示）
-  const [setterDisplay, setSetterDisplay] = useState("none");
+  // none: 非表示 / button: ＋ボタン / list: カード選択一覧
+  const [setterDisplay, setSetterDisplay] = useState<"none" | "button" | "list">("none");
 
   const handleClick = (key: string) => {
     setCardList(
@@ -28,12 +28,11 @@ export default function Setter(props: {
   };
 
   if (!cardMap || !cardList) {
-    return null; // cardMap または cardList が未定義の場合は何も表示しない
+    return null;
   }
 
   const componentKeys = Object.keys(cardMap);
 
-  // StyleSetting のような 2 単語で構成される文字列を改行する関数
   const formatKey = (key: string) => {
     return key.replace(/([a-z])([A-Z])/g, "$1\n$2");
   };
@@ -41,52 +40,47 @@ export default function Setter(props: {
   return (
     <div className="relative">
       <div
-        className={"absolute w-56 h-56 text-center"}
+        className="absolute w-56 h-56 text-center"
         style={{
-          left: item.x * 224, // 224 は カードの幅
-          top: item.y * 224, // 224 は カードの幅
+          left: item.x * 224,
+          top: item.y * 224,
           color: fontColor,
         }}
+        // ＋と一覧を同じホバー領域に置く。
+        // 以前は一覧が領域外だったため、＋クリック直後に mouseLeave で list が消えていた。
+        onMouseEnter={() =>
+          setSetterDisplay((prev) => (prev === "none" ? "button" : prev))
+        }
+        onMouseLeave={() => setSetterDisplay("none")}
       >
-        <div
-          className="w-full h-full flex items-center justify-center"
-          onMouseEnter={() => setSetterDisplay("button")}
-          onMouseLeave={() => setSetterDisplay("none")}
-        >
-          {setterDisplay === "button" && (
-            <button
-              className="w-full h-full text-6xl backdrop-brightness-75 border-2 border-dashed duration-200"
-              onClick={() => setSetterDisplay("list")}
-              style={{
-                borderColor: fontColor,
-              }}
-            >
-              +
-            </button>
-          )}
-        </div>
+        {setterDisplay === "button" && (
+          <button
+            className="w-full h-full text-6xl backdrop-brightness-75 border-2 border-dashed duration-200"
+            onClick={() => setSetterDisplay("list")}
+            style={{
+              borderColor: fontColor,
+            }}
+          >
+            +
+          </button>
+        )}
         {setterDisplay === "list" && (
-          <div className="absolute inset-0 flex items-center justify-center">
-            <div
-              className="w-full h-full grid grid-cols-4 grid-rows-4"
-              onMouseLeave={() => setSetterDisplay("none")}
-            >
-              {componentKeys.map((key, index) => (
-                <button
-                  key={index}
-                  className="flex items-center justify-center text-xs duration-200 hover:brightness-150"
-                  onClick={() => handleClick(key)}
-                  style={{
-                    backgroundColor: bgColor,
-                    borderColor: fontColor,
-                    borderWidth: 1,
-                    borderStyle: "dashed",
-                  }}
-                >
-                  {formatKey(key.charAt(0).toUpperCase() + key.slice(1))}
-                </button>
-              ))}
-            </div>
+          <div className="w-full h-full grid grid-cols-4 grid-rows-4">
+            {componentKeys.map((key, index) => (
+              <button
+                key={index}
+                className="flex items-center justify-center text-xs duration-200 hover:brightness-150"
+                onClick={() => handleClick(key)}
+                style={{
+                  backgroundColor: bgColor,
+                  borderColor: fontColor,
+                  borderWidth: 1,
+                  borderStyle: "dashed",
+                }}
+              >
+                {formatKey(key.charAt(0).toUpperCase() + key.slice(1))}
+              </button>
+            ))}
           </div>
         )}
       </div>

--- a/components/card/Coin.tsx
+++ b/components/card/Coin.tsx
@@ -1,114 +1,120 @@
 "use client";
 
-import { Canvas, useFrame } from "@react-three/fiber";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
-import { useState, useMemo } from "react";
-import { Euler } from "three";
+import { useState, useMemo, useRef, useCallback, useEffect } from "react";
+import { Group } from "three";
 
-// ==============================
-// 設定
-const modelPath = "Coin.glb"; // コインモデルのパス
+function KickFrame({ active }: { active: boolean }) {
+  const { invalidate } = useThree();
+  useEffect(() => {
+    invalidate();
+    if (!active) return;
+    let id = 0;
+    const loop = () => {
+      invalidate();
+      id = requestAnimationFrame(loop);
+    };
+    id = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(id);
+  }, [active, invalidate]);
+  return null;
+}
 
-// コインモデル単体
+const modelPath = "Coin.glb";
+
 function CoinModel() {
   const { scene } = useGLTF(modelPath);
-
-  // モデルのクローン（コインカードを複数作成するため）
   const clonedScene = useMemo(() => scene.clone(), [scene]);
 
   return (
     <primitive
       object={clonedScene}
-      // 今回はコインの中心が原点になるように調整
-      position={[0, 0, 0]} // モデルの位置
-      scale={[10, 10, 10]} // モデルの大きさ
+      position={[0, 0, 0]}
+      scale={[10, 10, 10]}
     />
   );
 }
 
-// グループ（複数のモデルの集合）
-function Group() {
-  const [rotation, setRotation] = useState(
-    new Euler((2 * Math.PI) / 2, (2 * Math.PI) / 2, (2 * Math.PI) / 2)
-  );
+function GroupComponent() {
+  const groupRef = useRef<Group>(null);
   const [isFlipping, setIsFlipping] = useState(false);
-  const [isFlippingLast, setIsFlippingLast] = useState(false);
+  const isFlippingRef = useRef(false);
+  const isFlippingLastRef = useRef(false);
+  const { invalidate } = useThree();
 
   useFrame(() => {
-    if (isFlipping === isFlippingLast) {
-      // モデルの回転
-      if (isFlipping) {
-        setRotation(
-          (prevRotation) =>
-            new Euler(
-              prevRotation.x + (Math.PI * 15) / 100,
-              prevRotation.y,
-              prevRotation.z
-            )
-        );
+    const group = groupRef.current;
+    if (!group) return;
+
+    if (isFlippingRef.current === isFlippingLastRef.current) {
+      if (isFlippingRef.current) {
+        group.rotation.x += (Math.PI * 15) / 100;
+        invalidate();
       }
     } else {
-      // コインフリップの切り替え時にランダムな回転角にする
-      setRotation(
-        (prevRotation) =>
-          new Euler(
-            ((Math.floor(Math.random() * 2) + 1) * Math.PI),
-            prevRotation.y,
-            prevRotation.z,
-          )
-      );
-      setIsFlippingLast(isFlipping);
+      group.rotation.x = (Math.floor(Math.random() * 2) + 1) * Math.PI;
+      isFlippingLastRef.current = isFlippingRef.current;
+      invalidate();
     }
   });
 
+  const handleClick = useCallback(() => {
+    setIsFlipping((prev) => {
+      const next = !prev;
+      isFlippingRef.current = next;
+      return next;
+    });
+  }, []);
+
   return (
-    <group
-      rotation={rotation} // モデルの回転
-      onClick={() => {
-        // クリック時の処理
-        setIsFlipping(!isFlipping);
-      }}
-    >
-      {/* モデル */}
-      <CoinModel />
-    </group>
+    <>
+      <KickFrame active={isFlipping} />
+      <group
+        ref={groupRef}
+        rotation={[(2 * Math.PI) / 2, (2 * Math.PI) / 2, (2 * Math.PI) / 2]}
+        onClick={handleClick}
+      >
+        <CoinModel />
+      </group>
+    </>
   );
 }
 
-export default function Coin(props: { zoomRatio: number }) {
-  const { zoomRatio } = props;
+export default function Coin(props: { zoomRatio: number; isActive?: boolean }) {
+  const { zoomRatio, isActive = true } = props;
+
   return (
     <>
-      <Canvas
-        className="h-full w-full"
-        camera={{
-          fov: 70, // 視野角
-          position: [0, 0, 50], // カメラの位置
-        }}
-        style={{
-          zoom: 1 / zoomRatio, // キャンバスの拡大
-        }}
-      >
-        {/* グループ */}
-        <Group />
-
-        {/* カメラ操作 https://threejs.org/docs/#examples/en/controls/OrbitControls */}
-        <OrbitControls
-          minDistance={120} // ズームの最小距離
-          maxDistance={153} // ズームの最大距離
-          minPolarAngle={(Math.PI * -0) / 100} // カメラの上下回転角度の最小値
-          maxPolarAngle={(Math.PI * 0) / 100} // カメラの上下回転角度の最大値
-          minAzimuthAngle={(Math.PI * -0) / 100} // カメラの左右回転角度の最小値
-          maxAzimuthAngle={(Math.PI * 0) / 100} // カメラの左右回転角度の最大値
-        />
-
-        {/* ライト */}
-        <directionalLight intensity={5} position={[10, 25, 80]} />
-        <ambientLight intensity={0.2} />
-
-        {/* パフォーマンスモニター */}
-        {/* <Stats /> */}
-      </Canvas>
+      {isActive ? (
+        <Canvas
+          className="h-full w-full"
+          camera={{
+            fov: 70,
+            position: [0, 0, 50],
+          }}
+          style={{
+            zoom: 1 / zoomRatio,
+          }}
+          frameloop="demand"
+          dpr={[1, 1.5]}
+          gl={{ antialias: false, powerPreference: "low-power" }}
+        >
+          <GroupComponent />
+          <OrbitControls
+            minDistance={120}
+            maxDistance={153}
+            minPolarAngle={(Math.PI * -0) / 100}
+            maxPolarAngle={(Math.PI * 0) / 100}
+            minAzimuthAngle={(Math.PI * -0) / 100}
+            maxAzimuthAngle={(Math.PI * 0) / 100}
+          />
+          <directionalLight intensity={5} position={[10, 25, 80]} />
+          <ambientLight intensity={0.2} />
+        </Canvas>
+      ) : (
+        <div className="h-full w-full" aria-hidden />
+      )}
     </>
   );
 }

--- a/components/card/Coin.tsx
+++ b/components/card/Coin.tsx
@@ -1,25 +1,10 @@
 "use client";
 
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
-import { useState, useMemo, useRef, useCallback, useEffect } from "react";
+import { useMemo, useRef, useCallback } from "react";
 import { Group } from "three";
-
-function KickFrame({ active }: { active: boolean }) {
-  const { invalidate } = useThree();
-  useEffect(() => {
-    invalidate();
-    if (!active) return;
-    let id = 0;
-    const loop = () => {
-      invalidate();
-      id = requestAnimationFrame(loop);
-    };
-    id = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(id);
-  }, [active, invalidate]);
-  return null;
-}
+import type { ThreeEvent } from "@react-three/fiber";
 
 const modelPath = "Coin.glb";
 
@@ -38,10 +23,8 @@ function CoinModel() {
 
 function GroupComponent() {
   const groupRef = useRef<Group>(null);
-  const [isFlipping, setIsFlipping] = useState(false);
   const isFlippingRef = useRef(false);
   const isFlippingLastRef = useRef(false);
-  const { invalidate } = useThree();
 
   useFrame(() => {
     const group = groupRef.current;
@@ -50,34 +33,26 @@ function GroupComponent() {
     if (isFlippingRef.current === isFlippingLastRef.current) {
       if (isFlippingRef.current) {
         group.rotation.x += (Math.PI * 15) / 100;
-        invalidate();
       }
     } else {
       group.rotation.x = (Math.floor(Math.random() * 2) + 1) * Math.PI;
       isFlippingLastRef.current = isFlippingRef.current;
-      invalidate();
     }
   });
 
-  const handleClick = useCallback(() => {
-    setIsFlipping((prev) => {
-      const next = !prev;
-      isFlippingRef.current = next;
-      return next;
-    });
+  const handlePointerDown = useCallback((e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    isFlippingRef.current = !isFlippingRef.current;
   }, []);
 
   return (
-    <>
-      <KickFrame active={isFlipping} />
-      <group
-        ref={groupRef}
-        rotation={[(2 * Math.PI) / 2, (2 * Math.PI) / 2, (2 * Math.PI) / 2]}
-        onClick={handleClick}
-      >
-        <CoinModel />
-      </group>
-    </>
+    <group
+      ref={groupRef}
+      rotation={[(2 * Math.PI) / 2, (2 * Math.PI) / 2, (2 * Math.PI) / 2]}
+      onPointerDown={handlePointerDown}
+    >
+      <CoinModel />
+    </group>
   );
 }
 
@@ -96,7 +71,6 @@ export default function Coin(props: { zoomRatio: number; isActive?: boolean }) {
           style={{
             zoom: 1 / zoomRatio,
           }}
-          frameloop="demand"
           dpr={[1, 1.5]}
           gl={{ antialias: false, powerPreference: "low-power" }}
         >
@@ -108,6 +82,9 @@ export default function Coin(props: { zoomRatio: number; isActive?: boolean }) {
             maxPolarAngle={(Math.PI * 0) / 100}
             minAzimuthAngle={(Math.PI * -0) / 100}
             maxAzimuthAngle={(Math.PI * 0) / 100}
+            enableRotate={false}
+            enableZoom={false}
+            enablePan={false}
           />
           <directionalLight intensity={5} position={[10, 25, 80]} />
           <ambientLight intensity={0.2} />

--- a/components/card/Dice.tsx
+++ b/components/card/Dice.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Canvas, useFrame } from "@react-three/fiber";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
-import { useState, useMemo, useEffect, useCallback } from "react";
-import { Euler } from "three";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { Euler, Group } from "three";
 
 // ==============================
 // 型定義
@@ -50,8 +50,8 @@ const diceTypes: DiceTypes = {
       new Euler(-Math.PI / 2, 0, 0),
       new Euler(0, 0, Math.PI / 2),
       new Euler(0, 0, -Math.PI / 2),
-      new Euler(Math.PI, 0, 0)
-    ]
+      new Euler(Math.PI, 0, 0),
+    ],
   },
   d20: {
     modelPath: "Dice_20.glb",
@@ -65,82 +65,68 @@ const diceTypes: DiceTypes = {
     position: [0, 0, 0],
     maxValue: 20,
     eulers: [
-      new Euler(2.281594635649414, 2.7364837123268737, 0.46752905169531833), // 1
-      new Euler(2.1329691446641348, 6.134649083647228, 3.305001660001041), // 2
-      new Euler(2.3193434262335735, 3.2847295930698245, 5.446634381780314), // 3
-      new Euler(6.278464803475794, 3.6758206415915864, 5.732631696386318), // 4
-      new Euler(1.9110104546349074, 1.3849923221166003, 1.409861144114713), // 5
-      new Euler(1.129774579899926, 3.096048908848052, 5.668938888734065), // 6
-      new Euler(6.078385611352912, 5.853985208610443, 0.6719989399062191), // 7
-      new Euler(5.735207411848094, 4.532278199506348, 2.4597113845158978), // 8
-      new Euler(1.381144516894394, 3.863382759749827, 6.251253607998515), // 9
-      new Euler(1.0066123767655852, 0.4834038972723187, 3.9782125074423965), // 10
-      new Euler(1.702892540125957, 5.725014387652284, 0.8611688443707862), // 11
-      new Euler(2.8623545613968244, 1.6426512776530358, 1.745647249052657), // 12
-      new Euler(1.585823099427606, 2.6217073675809703, 1.1126693899847808), // 13
-      new Euler(2.411671741221388, 6.244476079017044, 5.396571586383581), // 14
-      new Euler(0.9580497323326584, 0.478848416061389, 2.6996472829175273), // 15
-      new Euler(1.6810075306228713, 2.2890730247237423, 4.890603643619729), // 16
-      new Euler(5.543978808669293, 0.056539120429048524, 0.8341191002506894), // 17
-      new Euler(0.5183588895568026, 2.8676940228557144, 2.3590613468466524), // 18
-      new Euler(5.417709666430658, 0.43647968081176275, 2.754869759867071), // 19
-      new Euler(5.5853625767868635, 2.5303617386887964, 0.23988265126975464), // 20
-    ]
-  }
+      new Euler(2.281594635649414, 2.7364837123268737, 0.46752905169531833),
+      new Euler(2.1329691446641348, 6.134649083647228, 3.305001660001041),
+      new Euler(2.3193434262335735, 3.2847295930698245, 5.446634381780314),
+      new Euler(6.278464803475794, 3.6758206415915864, 5.732631696386318),
+      new Euler(1.9110104546349074, 1.3849923221166003, 1.409861144114713),
+      new Euler(1.129774579899926, 3.096048908848052, 5.668938888734065),
+      new Euler(6.078385611352912, 5.853985208610443, 0.6719989399062191),
+      new Euler(5.735207411848094, 4.532278199506348, 2.4597113845158978),
+      new Euler(1.381144516894394, 3.863382759749827, 6.251253607998515),
+      new Euler(1.0066123767655852, 0.4834038972723187, 3.9782125074423965),
+      new Euler(1.702892540125957, 5.725014387652284, 0.8611688443707862),
+      new Euler(2.8623545613968244, 1.6426512776530358, 1.745647249052657),
+      new Euler(1.585823099427606, 2.6217073675809703, 1.1126693899847808),
+      new Euler(2.411671741221388, 6.244476079017044, 5.396571586383581),
+      new Euler(0.9580497323326584, 0.478848416061389, 2.6996472829175273),
+      new Euler(1.6810075306228713, 2.2890730247237423, 4.890603643619729),
+      new Euler(5.543978808669293, 0.056539120429048524, 0.8341191002506894),
+      new Euler(0.5183588895568026, 2.8676940228557144, 2.3590613468466524),
+      new Euler(5.417709666430658, 0.43647968081176275, 2.754869759867071),
+      new Euler(5.5853625767868635, 2.5303617386887964, 0.23988265126975464),
+    ],
+  },
 };
 
 // ==============================
-// カスタムフック - ダイスロジック
+// カスタムフック - ダイスロジック（ref 更新で React 再レンダーを回避）
 // ==============================
-function useDiceLogic(diceType: DiceDimensions) {
-  const [rotation, setRotation] = useState(
-    diceTypes[diceType].eulers[2] // 6面ダイスの "6" の面
-  );
+function useDiceLogic(diceType: DiceDimensions, groupRef: React.RefObject<Group | null>) {
   const [isRolling, setIsRolling] = useState(false);
-  const [isRollingLast, setIsRollingLast] = useState(false);
+  const isRollingRef = useRef(false);
+  const isRollingLastRef = useRef(false);
+  const { invalidate } = useThree();
 
-  // ダイスを転がすハンドラー
   const rollDice = useCallback(() => {
-    setIsRolling(!isRolling);
-  }, [isRolling]);
+    setIsRolling((prev) => {
+      const next = !prev;
+      isRollingRef.current = next;
+      return next;
+    });
+  }, []);
 
   useFrame(() => {
-    if (isRolling === isRollingLast) {
-      // モデルの回転
-      if (isRolling) {
-        setRotation(
-          (prevRotation) =>
-            new Euler(
-              prevRotation.x + (Math.PI * 15) / 100,
-              prevRotation.y + (Math.PI * 15) / 100,
-              prevRotation.z + (Math.PI * 15) / 100
-            )
-        );
+    const group = groupRef.current;
+    if (!group) return;
+
+    if (isRollingRef.current === isRollingLastRef.current) {
+      if (isRollingRef.current) {
+        group.rotation.x += (Math.PI * 15) / 100;
+        group.rotation.y += (Math.PI * 15) / 100;
+        group.rotation.z += (Math.PI * 15) / 100;
+        invalidate();
       }
     } else {
-      // eulers の値を総当たりで取得する際に使ったコード
-      // const randomNums = {
-      //   x: Math.random() * Math.PI,
-      //   y: Math.random() * Math.PI,
-      //   z: Math.random() * Math.PI
-      // }
-      // console.log("new Euler(" + randomNums.x + "," + randomNums.y + "," + randomNums.z + "),");
-      // setRotation(
-      //   new Euler(randomNums.x, randomNums.y, randomNums.z)
-      // );
       const randomIndex = Math.floor(Math.random() * diceTypes[diceType].maxValue);
-      setRotation(
-        diceTypes[diceType].eulers[randomIndex]
-      );
-      setIsRollingLast(isRolling);
+      const euler = diceTypes[diceType].eulers[randomIndex];
+      group.rotation.copy(euler);
+      isRollingLastRef.current = isRollingRef.current;
+      invalidate();
     }
   });
 
-  return {
-    rotation,
-    isRolling,
-    rollDice
-  };
+  return { isRolling, rollDice };
 }
 
 // ==============================
@@ -162,70 +148,94 @@ function DiceModel({ diceType }: { diceType: DiceDimensions }) {
 // ==============================
 // グループコンポーネント
 // ==============================
+function KickFrame({ active }: { active: boolean }) {
+  const { invalidate } = useThree();
+  useEffect(() => {
+    invalidate();
+    if (!active) return;
+    let id = 0;
+    const loop = () => {
+      invalidate();
+      id = requestAnimationFrame(loop);
+    };
+    id = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(id);
+  }, [active, invalidate]);
+  return null;
+}
+
 function DiceGroup({ diceType }: { diceType: DiceDimensions }) {
-  const { rotation, rollDice } = useDiceLogic(diceType);
+  const groupRef = useRef<Group>(null);
+  const { isRolling, rollDice } = useDiceLogic(diceType, groupRef);
+  const initialEuler = diceTypes[diceType].eulers[2];
+
   return (
-    <group
-      rotation={rotation}
-      onClick={rollDice}
-    >
-      <DiceModel diceType={diceType} />
-    </group>
+    <>
+      <KickFrame active={isRolling} />
+      <group
+        ref={groupRef}
+        rotation={[initialEuler.x, initialEuler.y, initialEuler.z]}
+        onClick={rollDice}
+      >
+        <DiceModel diceType={diceType} />
+      </group>
+    </>
   );
 }
 
 // ==============================
 // メインコンポーネント
 // ==============================
-export default function Dice(props: { zoomRatio: number }) {
-  const { zoomRatio } = props;
-  const [selectedDiceType, setSelectedDiceType] = useState<DiceDimensions>('d6');
+export default function Dice(props: { zoomRatio: number; isActive?: boolean }) {
+  const { zoomRatio, isActive = true } = props;
+  const [selectedDiceType, setSelectedDiceType] = useState<DiceDimensions>("d6");
   const config = diceTypes[selectedDiceType];
 
-  // モデルの事前読み込み
+  // アクティブ時のみ現在のモデルをプリロード（両方一括ロードしない）
   useEffect(() => {
+    if (!isActive) return;
     try {
-      Object.values(diceTypes).forEach(type => {
-        useGLTF.preload(type.modelPath);
-      });
+      useGLTF.preload(diceTypes[selectedDiceType].modelPath);
     } catch (error) {
       console.error("モデルのプリロードに失敗しました:", error);
     }
-  }, []);
+  }, [isActive, selectedDiceType]);
 
-  // ダイスタイプ切り替えハンドラー
   const toggleDiceType = useCallback(() => {
-    setSelectedDiceType(prev => prev === 'd6' ? 'd20' : 'd6');
+    setSelectedDiceType((prev) => (prev === "d6" ? "d20" : "d6"));
   }, []);
 
   return (
     <div className="h-full w-full relative">
-      <Canvas
-        className="h-full w-full"
-        style={{ zoom: 1 / zoomRatio, }}
-      >
-        {/* グループ */}
-        <DiceGroup diceType={selectedDiceType} />
+      {isActive ? (
+        <Canvas
+          className="h-full w-full"
+          style={{ zoom: 1 / zoomRatio }}
+          frameloop="demand"
+          dpr={[1, 1.5]}
+          gl={{ antialias: false, powerPreference: "low-power" }}
+        >
+          <DiceGroup diceType={selectedDiceType} />
+          <OrbitControls
+            minDistance={config.minDistance}
+            maxDistance={config.maxDistance}
+            minPolarAngle={config.minPolarAngle}
+            maxPolarAngle={config.maxPolarAngle}
+            minAzimuthAngle={config.minAzimuthAngle}
+            maxAzimuthAngle={config.maxAzimuthAngle}
+            enablePan={false}
+          />
+          <directionalLight intensity={5} position={[10, 20, 50]} />
+          <ambientLight intensity={0.5} />
+        </Canvas>
+      ) : (
+        <div className="h-full w-full" aria-hidden />
+      )}
 
-        {/* カメラ操作 */}
-        <OrbitControls
-          minDistance={config.minDistance}
-          maxDistance={config.maxDistance}
-          minPolarAngle={config.minPolarAngle}
-          maxPolarAngle={config.maxPolarAngle}
-          minAzimuthAngle={config.minAzimuthAngle}
-          maxAzimuthAngle={config.maxAzimuthAngle}
-          enablePan={false}
-        />
-
-        {/* ライト */}
-        <directionalLight intensity={5} position={[10, 20, 50]} castShadow />
-        <ambientLight intensity={0.5} />
-      </Canvas>
-
-      {/* ダイス選択UI */}
       <button
-        className={"absolute z-10 block bottom-2 left-1/2 -translate-x-1/2 w-16 text-xl text-center duration-200 hover:opacity-80"}
+        className={
+          "absolute z-10 block bottom-2 left-1/2 -translate-x-1/2 w-16 text-xl text-center duration-200 hover:opacity-80"
+        }
         onClick={toggleDiceType}
       >
         {selectedDiceType}

--- a/components/card/Dice.tsx
+++ b/components/card/Dice.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { Euler, Group } from "three";
+import type { ThreeEvent } from "@react-three/fiber";
 
 // ==============================
 // 型定義
@@ -93,17 +94,12 @@ const diceTypes: DiceTypes = {
 // カスタムフック - ダイスロジック（ref 更新で React 再レンダーを回避）
 // ==============================
 function useDiceLogic(diceType: DiceDimensions, groupRef: React.RefObject<Group | null>) {
-  const [isRolling, setIsRolling] = useState(false);
   const isRollingRef = useRef(false);
   const isRollingLastRef = useRef(false);
-  const { invalidate } = useThree();
 
-  const rollDice = useCallback(() => {
-    setIsRolling((prev) => {
-      const next = !prev;
-      isRollingRef.current = next;
-      return next;
-    });
+  const rollDice = useCallback((e?: ThreeEvent<PointerEvent>) => {
+    e?.stopPropagation();
+    isRollingRef.current = !isRollingRef.current;
   }, []);
 
   useFrame(() => {
@@ -115,18 +111,15 @@ function useDiceLogic(diceType: DiceDimensions, groupRef: React.RefObject<Group 
         group.rotation.x += (Math.PI * 15) / 100;
         group.rotation.y += (Math.PI * 15) / 100;
         group.rotation.z += (Math.PI * 15) / 100;
-        invalidate();
       }
     } else {
       const randomIndex = Math.floor(Math.random() * diceTypes[diceType].maxValue);
-      const euler = diceTypes[diceType].eulers[randomIndex];
-      group.rotation.copy(euler);
+      group.rotation.copy(diceTypes[diceType].eulers[randomIndex]);
       isRollingLastRef.current = isRollingRef.current;
-      invalidate();
     }
   });
 
-  return { isRolling, rollDice };
+  return { rollDice };
 }
 
 // ==============================
@@ -148,38 +141,20 @@ function DiceModel({ diceType }: { diceType: DiceDimensions }) {
 // ==============================
 // グループコンポーネント
 // ==============================
-function KickFrame({ active }: { active: boolean }) {
-  const { invalidate } = useThree();
-  useEffect(() => {
-    invalidate();
-    if (!active) return;
-    let id = 0;
-    const loop = () => {
-      invalidate();
-      id = requestAnimationFrame(loop);
-    };
-    id = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(id);
-  }, [active, invalidate]);
-  return null;
-}
-
 function DiceGroup({ diceType }: { diceType: DiceDimensions }) {
   const groupRef = useRef<Group>(null);
-  const { isRolling, rollDice } = useDiceLogic(diceType, groupRef);
+  const { rollDice } = useDiceLogic(diceType, groupRef);
   const initialEuler = diceTypes[diceType].eulers[2];
 
   return (
-    <>
-      <KickFrame active={isRolling} />
-      <group
-        ref={groupRef}
-        rotation={[initialEuler.x, initialEuler.y, initialEuler.z]}
-        onClick={rollDice}
-      >
-        <DiceModel diceType={diceType} />
-      </group>
-    </>
+    <group
+      ref={groupRef}
+      rotation={[initialEuler.x, initialEuler.y, initialEuler.z]}
+      // モバイルでは onClick より onPointerDown の方が確実
+      onPointerDown={rollDice}
+    >
+      <DiceModel diceType={diceType} />
+    </group>
   );
 }
 
@@ -211,7 +186,7 @@ export default function Dice(props: { zoomRatio: number; isActive?: boolean }) {
         <Canvas
           className="h-full w-full"
           style={{ zoom: 1 / zoomRatio }}
-          frameloop="demand"
+          // 表示中 Canvas は常時描画（demand + KickFrame だとタップ後の反映漏れが起きる）
           dpr={[1, 1.5]}
           gl={{ antialias: false, powerPreference: "low-power" }}
         >
@@ -224,6 +199,9 @@ export default function Dice(props: { zoomRatio: number; isActive?: boolean }) {
             minAzimuthAngle={config.minAzimuthAngle}
             maxAzimuthAngle={config.maxAzimuthAngle}
             enablePan={false}
+            // タップを回転として飲み込まないよう、タッチ回転は無効化
+            enableRotate={false}
+            enableZoom={false}
           />
           <directionalLight intensity={5} position={[10, 20, 50]} />
           <ambientLight intensity={0.5} />

--- a/components/card/Roulette.tsx
+++ b/components/card/Roulette.tsx
@@ -1,25 +1,10 @@
 "use client";
 
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useRef, useCallback } from "react";
 import { Group } from "three";
-
-function KickFrame({ active }: { active: boolean }) {
-  const { invalidate } = useThree();
-  useEffect(() => {
-    invalidate();
-    if (!active) return;
-    let id = 0;
-    const loop = () => {
-      invalidate();
-      id = requestAnimationFrame(loop);
-    };
-    id = requestAnimationFrame(loop);
-    return () => cancelAnimationFrame(id);
-  }, [active, invalidate]);
-  return null;
-}
+import type { ThreeEvent } from "@react-three/fiber";
 
 type user = {
   name: string;
@@ -43,7 +28,7 @@ function RouletteModel(props: { users: Array<user> }) {
                 10,
                 10,
                 2,
-                24, // 頂点数を削減してモバイル負荷を下げる
+                24,
                 1,
                 false,
                 -rad,
@@ -74,7 +59,6 @@ function GroupComponent(props: {
   const isSpinningLastRef = useRef(true);
   const angularVelocityRef = useRef(initialAngularVelocity);
   const rotationYRef = useRef(1 * Math.PI);
-  const { invalidate } = useThree();
 
   useFrame(() => {
     const group = groupRef.current;
@@ -91,7 +75,6 @@ function GroupComponent(props: {
         }
         rotationYRef.current += angularVelocityRef.current;
         group.rotation.y = rotationYRef.current;
-        invalidate();
       } else {
         setIsSpinning(false);
         isSpinningRef.current = false;
@@ -109,7 +92,8 @@ function GroupComponent(props: {
     }
   });
 
-  const handleClick = useCallback(() => {
+  const handlePointerDown = useCallback((e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
     if (!isSpinningRef.current && !isSpinningLastRef.current) {
       rotationYRef.current = Math.random() * Math.PI * 2;
       if (groupRef.current) {
@@ -118,31 +102,31 @@ function GroupComponent(props: {
       setIsSpinning(true);
       isSpinningRef.current = true;
       isSpinningLastRef.current = false;
-      invalidate();
     }
-  }, [invalidate]);
+  }, []);
 
   return (
-    <>
-      <KickFrame active={isSpinning} />
-      <group ref={groupRef} rotation={[0, rotationYRef.current, 0]} onClick={handleClick}>
-        <mesh position={[0, 1.25, 0]}>
-          <cylinderGeometry args={[5, 5, 0.5, 24]} />
-          <meshStandardMaterial
-            color={isSpinning ? 0xffffff : users[rouletteNum].color}
-            roughness={0.4}
-            metalness={0.1}
-          />
-        </mesh>
+    <group
+      ref={groupRef}
+      rotation={[0, rotationYRef.current, 0]}
+      onPointerDown={handlePointerDown}
+    >
+      <mesh position={[0, 1.25, 0]}>
+        <cylinderGeometry args={[5, 5, 0.5, 24]} />
+        <meshStandardMaterial
+          color={isSpinning ? 0xffffff : users[rouletteNum].color}
+          roughness={0.4}
+          metalness={0.1}
+        />
+      </mesh>
 
-        <mesh position={[0, 3.25, 0]}>
-          <cylinderGeometry args={[2.5, 4.5, 3.5, 8]} />
-          <meshStandardMaterial color={0xffffff} roughness={0.4} metalness={0.1} />
-        </mesh>
+      <mesh position={[0, 3.25, 0]}>
+        <cylinderGeometry args={[2.5, 4.5, 3.5, 8]} />
+        <meshStandardMaterial color={0xffffff} roughness={0.4} metalness={0.1} />
+      </mesh>
 
-        <RouletteModel users={users} />
-      </group>
-    </>
+      <RouletteModel users={users} />
+    </group>
   );
 }
 
@@ -164,7 +148,6 @@ export default function Roulette(props: {
           className="h-full w-full"
           camera={{ fov: 80, position: [10, 3, 0] }}
           style={{ background: "transparent", zoom: 1 / zoomRatio }}
-          frameloop="demand"
           dpr={[1, 1.5]}
           gl={{ antialias: false, powerPreference: "low-power" }}
         >
@@ -180,6 +163,9 @@ export default function Roulette(props: {
             maxPolarAngle={(0.6 * Math.PI) / 2}
             minAzimuthAngle={0}
             maxAzimuthAngle={0}
+            enableRotate={false}
+            enableZoom={false}
+            enablePan={false}
           />
           <ambientLight intensity={0.8} />
           <directionalLight intensity={2.5} position={[20, 50, -25]} />

--- a/components/card/Roulette.tsx
+++ b/components/card/Roulette.tsx
@@ -1,19 +1,33 @@
 "use client";
 
-import { Canvas, useFrame } from "@react-three/fiber";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
-import { useState } from "react";
-import { Euler } from "three";
+import { useState, useRef, useCallback, useEffect } from "react";
+import { Group } from "three";
+
+function KickFrame({ active }: { active: boolean }) {
+  const { invalidate } = useThree();
+  useEffect(() => {
+    invalidate();
+    if (!active) return;
+    let id = 0;
+    const loop = () => {
+      invalidate();
+      id = requestAnimationFrame(loop);
+    };
+    id = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(id);
+  }, [active, invalidate]);
+  return null;
+}
 
 type user = {
   name: string;
   color: string;
 };
 
-// 初期角速度
 const initialAngularVelocity = (Math.PI * 2 * 50) / 100;
 
-// ルーレット盤
 function RouletteModel(props: { users: Array<user> }) {
   const { users } = props;
 
@@ -26,20 +40,20 @@ function RouletteModel(props: { users: Array<user> }) {
           <mesh key={i} position={[0, 0, 0]}>
             <cylinderGeometry
               args={[
-                10, // 1ピースの上面の半径
-                10, // 1ピースの下面の半径
-                2, // 1ピースの高さ
-                32, // 1ピースの頂点数
+                10,
+                10,
+                2,
+                24, // 頂点数を削減してモバイル負荷を下げる
                 1,
                 false,
-                -rad, // 1ピースの開始角度
-                (Math.PI * 2) / users.length, // 1ピースの角度
+                -rad,
+                (Math.PI * 2) / users.length,
               ]}
             />
             <meshStandardMaterial
               color={user.color}
-              roughness={0.1} // ざらつき
-              metalness={0.2} // 金属感
+              roughness={0.1}
+              metalness={0.2}
             />
           </mesh>
         );
@@ -48,105 +62,84 @@ function RouletteModel(props: { users: Array<user> }) {
   );
 }
 
-// ルーレット全体
 function GroupComponent(props: {
   users: Array<user>;
   rouletteNum: number;
   setRouletteNum: (num: number) => void;
 }) {
   const { users, rouletteNum, setRouletteNum } = props;
-  const [rotation, setRotation] = useState(new Euler(0, 1 * Math.PI, 0));
-  const [isSpinning, setIsSpinning] = useState(false); // 回転状態の判定
-  const [isSpinningLast, setIsSpinningLast] = useState(true); // isSpinning だけでも表現はできるが、isSpinningLast を加えることで停止中の useFrame 内の計算をなしにできる
-  const [angularVelocity, setAngularVelocity] = useState(
-    // 角速度
-    initialAngularVelocity
-  );
+  const groupRef = useRef<Group>(null);
+  const [isSpinning, setIsSpinning] = useState(false);
+  const isSpinningRef = useRef(false);
+  const isSpinningLastRef = useRef(true);
+  const angularVelocityRef = useRef(initialAngularVelocity);
+  const rotationYRef = useRef(1 * Math.PI);
+  const { invalidate } = useThree();
 
   useFrame(() => {
-    if (isSpinning && !isSpinningLast) {
-      // ======================================
-      // 回転中の処理
-      // ======================================
-      if (angularVelocity != 0) {
-        // 次フレームの角速度の計算
-        setAngularVelocity((prevAngularVelocity) => {
-          if (prevAngularVelocity > 0) {
-            return (
-              prevAngularVelocity - // 現在の速度
-              prevAngularVelocity * 0.015 -
-              (Math.PI * 2 * 0.001) / 100
-            );
-          } else {
-            return 0;
-          }
-        });
-        // 計算した角速度をもとに次フレームの回転角を設定
-        setRotation(
-          (prevRotation) =>
-            new Euler(
-              prevRotation.x,
-              prevRotation.y + angularVelocity,
-              prevRotation.z
-            )
-        );
+    const group = groupRef.current;
+    if (!group) return;
+
+    if (isSpinningRef.current && !isSpinningLastRef.current) {
+      if (angularVelocityRef.current !== 0) {
+        const prev = angularVelocityRef.current;
+        if (prev > 0) {
+          angularVelocityRef.current =
+            prev - prev * 0.015 - (Math.PI * 2 * 0.001) / 100;
+        } else {
+          angularVelocityRef.current = 0;
+        }
+        rotationYRef.current += angularVelocityRef.current;
+        group.rotation.y = rotationYRef.current;
+        invalidate();
       } else {
-        // 角速度が 0 に収束した際は静止への移行状態をステートへ反映
         setIsSpinning(false);
-        setIsSpinningLast(true);
+        isSpinningRef.current = false;
+        isSpinningLastRef.current = true;
       }
-    } else if (!isSpinning && isSpinningLast) {
-      // ======================================
-      // 静止への移行処理
-      // ======================================
-      setAngularVelocity(initialAngularVelocity);
+    } else if (!isSpinningRef.current && isSpinningLastRef.current) {
+      angularVelocityRef.current = initialAngularVelocity;
       setRouletteNum(
         Math.round(
-          // (((回転角 + π<判定場所を手前側にずらすため>) % 2π) / 2π) * (色数 - 1)
-          (((rotation.y + Math.PI) % (Math.PI * 2)) / (Math.PI * 2)) *
-          (users.length - 1)
+          (((rotationYRef.current + Math.PI) % (Math.PI * 2)) / (Math.PI * 2)) *
+            (users.length - 1)
         )
       );
-      setIsSpinningLast(false);
+      isSpinningLastRef.current = false;
     }
   });
 
+  const handleClick = useCallback(() => {
+    if (!isSpinningRef.current && !isSpinningLastRef.current) {
+      rotationYRef.current = Math.random() * Math.PI * 2;
+      if (groupRef.current) {
+        groupRef.current.rotation.y = rotationYRef.current;
+      }
+      setIsSpinning(true);
+      isSpinningRef.current = true;
+      isSpinningLastRef.current = false;
+      invalidate();
+    }
+  }, [invalidate]);
+
   return (
     <>
-      {/* ルーレット全体 */}
-      <group
-        rotation={rotation}
-        onClick={() => {
-          // 静止状態のみトリガー
-          if (!isSpinning && !isSpinningLast) {
-            setRotation(new Euler(0, Math.random() * Math.PI * 2, 0));
-            setIsSpinning(true);
-            setIsSpinningLast(false);
-          }
-        }}
-      >
-        {/* 色判定用センターパーツ */}
+      <KickFrame active={isSpinning} />
+      <group ref={groupRef} rotation={[0, rotationYRef.current, 0]} onClick={handleClick}>
         <mesh position={[0, 1.25, 0]}>
-          <cylinderGeometry args={[5, 5, 0.5, 32]} />
+          <cylinderGeometry args={[5, 5, 0.5, 24]} />
           <meshStandardMaterial
             color={isSpinning ? 0xffffff : users[rouletteNum].color}
-            roughness={0.4} // ざらつき
-            metalness={0.1} // 金属感
+            roughness={0.4}
+            metalness={0.1}
           />
         </mesh>
 
-        {/* 持ち手パーツ */}
         <mesh position={[0, 3.25, 0]}>
           <cylinderGeometry args={[2.5, 4.5, 3.5, 8]} />
-          <meshStandardMaterial
-            color={0xffffff}
-            roughness={0.4} // ざらつき
-            metalness={0.1} // 金属感
-            // wireframe={true}
-          />
+          <meshStandardMaterial color={0xffffff} roughness={0.4} metalness={0.1} />
         </mesh>
 
-        {/* ルーレット本体 */}
         <RouletteModel users={users} />
       </group>
     </>
@@ -156,39 +149,45 @@ function GroupComponent(props: {
 export default function Roulette(props: {
   zoomRatio: number;
   players: Array<user>;
+  isActive?: boolean;
 }) {
-  const { zoomRatio, players } = props;
+  const { zoomRatio, players, isActive = true } = props;
   const [rouletteNum, setRouletteNum] = useState(0);
 
   return (
     <>
-      {/* 名前表示 */}
       <div className="absolute z-10 block top-3 right-1/2 translate-x-1/2 px-2 w-2/3 text-center text-2xl bg-opacity-80">
         {players[rouletteNum].name}
       </div>
-      {/* ルーレット3D描画 */}
-      <Canvas
-        className="h-full w-full"
-        camera={{ fov: 80, position: [10, 3, 0] }}
-        style={{ background: "transparent", zoom: 1 / zoomRatio }}
-      >
-        <GroupComponent
-          users={players}
-          rouletteNum={rouletteNum}
-          setRouletteNum={setRouletteNum}
-        />
-        <OrbitControls
-          minDistance={16}
-          maxDistance={25}
-          minPolarAngle={0}
-          maxPolarAngle={(0.6 * Math.PI) / 2}
-          minAzimuthAngle={0}
-          maxAzimuthAngle={0}
-        />
-        <ambientLight intensity={0.8} />
-        <directionalLight intensity={2.5} position={[20, 50, -25]} castShadow />
-        <directionalLight intensity={1.5} position={[20, 20, 55]} castShadow />
-      </Canvas>
+      {isActive ? (
+        <Canvas
+          className="h-full w-full"
+          camera={{ fov: 80, position: [10, 3, 0] }}
+          style={{ background: "transparent", zoom: 1 / zoomRatio }}
+          frameloop="demand"
+          dpr={[1, 1.5]}
+          gl={{ antialias: false, powerPreference: "low-power" }}
+        >
+          <GroupComponent
+            users={players}
+            rouletteNum={rouletteNum}
+            setRouletteNum={setRouletteNum}
+          />
+          <OrbitControls
+            minDistance={16}
+            maxDistance={25}
+            minPolarAngle={0}
+            maxPolarAngle={(0.6 * Math.PI) / 2}
+            minAzimuthAngle={0}
+            maxAzimuthAngle={0}
+          />
+          <ambientLight intensity={0.8} />
+          <directionalLight intensity={2.5} position={[20, 50, -25]} />
+          <directionalLight intensity={1.5} position={[20, 20, 55]} />
+        </Canvas>
+      ) : (
+        <div className="h-full w-full" aria-hidden />
+      )}
     </>
   );
 }

--- a/utils/cardFuncs.ts
+++ b/utils/cardFuncs.ts
@@ -18,17 +18,19 @@ export const setInitialCardsList = (
   maxRows: number,
   maxCols: number
 ): { component: string, x: number, y: number }[] => {
+  // 元配列を破壊しない（SP/PC で同じ initialCardsList を共有するため）
+  const result = initialCardsList.map((card) => ({ ...card }));
   for (let y = 0; y < maxRows; y++) {
     for (let x = 0; x < maxCols; x++) {
-      const existingComponent = initialCardsList.find(
+      const existingComponent = result.find(
         (comp) => comp.x === x && comp.y === y
       );
       if (!existingComponent) {
-        initialCardsList.push({ component: "setter", x, y });
+        result.push({ component: "setter", x, y });
       }
     }
   }
-  return initialCardsList;
+  return result;
 };
 
 /**

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -26,9 +26,11 @@ export type CardStyle = {
 
 export type CardComponent = React.ComponentType<{
   zoomRatio: number;
-  players:  Player[];
+  players: Player[];
   setPlayers: (arg: Player[]) => void;
   cardStyle: CardStyle;
   setCardStyle: (arg: CardStyle) => void;
   setCardList: (arg: CardSetting[]) => void;
+  /** SP: 前後カードのみ true。非アクティブ時は重い Canvas を破棄する */
+  isActive?: boolean;
 }>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
スマホ版の描画負荷を下げつつ、その過程で見つかった 3D タップ無反応と PC 版カード追加 UI の不具合も修正しました。

## Changes

### SP 軽量化
- 表示中カードのみ WebGL Canvas を起動（同時に最大 1 つ）
- Dice / Coin / Roulette は ref 直接更新で毎フレームの React 再レンダーを回避
- スワイプ blur 削除、カード本体を `memo`、タッチ座標は ref 管理
- SP では背景 PNG（約 800KB）を読まない
- Grid / GridSP を dynamic import

### 操作まわりの修正
- **3D タップ**: `frameloop="demand"` 競合を解消し、`onPointerDown` + OrbitControls のタッチ回転無効化
- **PC カード追加**: Setter の＋と一覧を同一ホバー領域に統合（クリック直後の `mouseLeave` で一覧が消える問題を修正）
- PC 読み込み時に空きマスの `setter` を補完

## Test plan
- [x] `npm run lint` / `npm run build` 成功
- [ ] SP: スワイプが滑らかで、ダイス・コイン・ルーレットが連続タップで確実に反応する
- [ ] SP: スコア / タイマー等を変更後、他カードへ移動して戻っても値が残る
- [ ] PC: 空きマス → ＋ → カード一覧が消えずに選択できる
- [ ] PC / SP 切り替え後もカード配置が破綻しない

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e1d4ec6-5605-4164-8fb0-9367d12838f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e1d4ec6-5605-4164-8fb0-9367d12838f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

