### PR TITLE
コード全体のモダン化と記述整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,85 +1,109 @@
-## 目的
-ボドゲ等を遊ぶ時のダイス、トークン、勝利点等を表示するためのアプリを作成する。
-当面は Cloudflare Pages にデプロイ。
+# Game Tools!
 
-https://boardgamefan.pages.dev/
+ボドゲ・カードゲームなどで使うダイス・トークン・勝利点などを、画面上でまとめて操作できるツールです。
 
-![開発中スクショ](image.png)
+配信・対面プレイのどちらでも使いやすいよう、PC ではグリッド配置、スマートフォンではスワイプ切替に対応しています。
 
-## 開発作業
+**デモ:** https://boardgamefan.pages.dev/
 
-### 開発メモ
-- 基本的にほぼすべてのレンダリングはクライアント側で行うが、TOPの layout.tsx だけはサーバーサイドで行う。
+![スクショ](image.png)
 
-### 初期導入・ライブラリインストール
-1. `npx create-next-app`
-2. `npm install three @react-three/fiber`
-3. `npm i @react-three/drei`
-4. `npm run dev`
+---
 
-### 開発中に使うスクリプト
-- ローカルストレージ削除（Chrome コンソール） `localStorage.clear()`
-- ローカルストレージ閲覧（Chrome コンソール） `console.log(localStorage)`
-- デプロイ前にビルドエラーを確認 `npm run lint`
+## できること
 
-### 本番ビルド関係
-1. 今回は Cloudflare Pages にデプロイするため静的ファイルを生成する
-   1. next.config.js に `output: 'export'` を追加
-2. `npm run build`
+| カード | 内容 |
+| --- | --- |
+| Dice | 6 面 / 20 面の 3D ダイス |
+| Coin | 3D コイントス |
+| Roulette | プレイヤー色で分割するルーレット |
+| Timer | カウントダウンタイマー |
+| Token / Score / OneOnOne | 各種カウンター |
+| Turn / Winner | ターン・勝利数管理 |
+| Player / Style | プレイヤー・見た目の設定 |
 
-### インフラ
-Cloudflare Pages にデプロイ
+設定（カード配置・スタイル・プレイヤー）はブラウザのローカルストレージに保存されます。
 
-1. Cloudflare Pages にログイン
-2. リポジトリを選択（すべてのリポジトリも選択できたがしなかった）
-3. ビルドコマンドを `npm run build` に設定
-4. 出力ディレクトリを `out` に設定
+---
 
-## 改善点
-- AI のさらなる積極利用
-- 大規模リファクタリング
-  - 関数等の記述方法を統一
-- セキュリティ向上
-  - ローカルストレージ暗号キーをハードコーディングからサーバー管理に移管
-  - CSP を追加
-- 追加カード
-  - 投票システム（要バックエンドサーバー）
-  - チーム分け（要バックエンドサーバー）
-  - 20 面ダイス
-- UI 改善
-  - サウンドエフェクト追加
-  - 紙吹雪追加
-  - SP のフォントを正しく動作するように修正
+## 開発環境
 
-## 参考URL
-- react-three-fiber, drei などの紹介
-  - あくまで紹介記事、導入のイメージ把握に使用
-  - https://zenn.dev/solb/articles/d25e664154cc0c
-  - https://hack.nikkei.com/blog/advent20231207/
-- Tailwind ドキュメント
-  - https://tailwindcss.com/docs
-- ReactThreeFiber ドキュメント
-  - 対して参考にならない・・・？
-  - https://r3f.docs.pmnd.rs/getting-started/introduction
-- Drei ドキュメント
-  - ドキュメントとしての用途もだが、サンプルコードが多く掲載されており助かる
-  - https://drei.docs.pmnd.rs/getting-started/introduction
-- Three.js ドキュメント
-  - 結局詳細な設定内容はここで確認することになる
-  - https://threejs.org/docs/index.html
-- Cloudflare Pages 紹介記事
-  - これだけでデプロイまでできてしまった
-  - https://zenn.dev/rivine/articles/2023-06-23-deploy-hugo-to-cloudflare-pages
-- Cloudflare Pages Docs
-  - デプロイが簡単にできすぎて全然読んでないが、かなり見やすそう
-  - https://developers.cloudflare.com/pages/
-- デザイン系
-  - https://colorhunt.co/
+### 必要環境
 
-## AI の使い方メモ
-Copilot Chat や Copilot Workspace を積極的に使用する。
+- Node.js 18 以上（推奨: 20 LTS）
+- npm
+
+### セットアップ
+
+```bash
+npm install
+npm run dev
 ```
-リファクタリングがしたいです。 セキュリティ的に問題がある場所もっと効率的に書ける場所があったら教えてください
 
-コードの提示は修正箇所のみでいいです。
+ブラウザで http://localhost:3000 を開きます。
+
+### 主なスクリプト
+
+| コマンド | 用途 |
+| --- | --- |
+| `npm run dev` | 開発サーバー起動 |
+| `npm run lint` | ESLint 実行 |
+| `npm run build` | 静的書き出し（`out/`） |
+| `npm start` | ビルド後のプレビュー |
+
+### ローカルストレージの確認（Chrome コンソール）
+
+```js
+localStorage.clear()   // 全削除
+console.log(localStorage)
 ```
+
+---
+
+## 構成のポイント
+
+- **レンダリング:** ほぼすべてクライアント側。`app/layout.tsx` のみサーバーコンポーネント。
+- **3D:** `@react-three/fiber` / `@react-three/drei` / `three`
+- **スタイル:** Tailwind CSS
+- **パスエイリアス:** `@/` → リポジトリルート
+- **SP 判定:** 画面幅 500px 未満で `GridSP`、それ以上で `Grid`
+
+```
+app/                 # Next.js App Router
+components/
+  Grid.tsx           # PC グリッド
+  GridSP.tsx         # SP スワイプ
+  card/              # 各ツールカード
+  card/module/       # 共通 UI（ドラッグ・閉じる・リセット）
+hooks/               # 共通フック（長押しなど）
+utils/               # 型・定数・localStorage・グリッド計算
+public/              # 3D モデル・アイコン・マニフェスト
+```
+
+---
+
+## デプロイ（Cloudflare Pages）
+
+本リポジトリは静的エクスポート前提です（`next.config.mjs` の `output: "export"`）。
+
+1. Cloudflare Pages でリポジトリを連携
+2. ビルドコマンド: `npm run build`
+3. 出力ディレクトリ: `out`
+
+---
+
+## 今後の改善候補
+
+- 投票・チーム分けなど、バックエンドが必要な機能
+- 効果音・紙吹雪などの演出
+- CSP の強化（現状は静的ホスト＋ローカル設定のみ）
+
+---
+
+## 参考リンク
+
+- [React Three Fiber](https://r3f.docs.pmnd.rs/getting-started/introduction)
+- [Drei](https://drei.docs.pmnd.rs/getting-started/introduction)
+- [Three.js Docs](https://threejs.org/docs/index.html)
+- [Tailwind CSS](https://tailwindcss.com/docs)
+- [Cloudflare Pages Docs](https://developers.cloudflare.com/pages/)

--- a/app/globals.css
+++ b/app/globals.css
@@ -19,20 +19,42 @@ body {
   background: var(--background);
 }
 
+/* number input のスピンボタンを非表示（見た目を揃える） */
 @layer base {
   input[type="number"]::-webkit-inner-spin-button,
   input[type="number"]::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
   }
+
+  input[type="number"] {
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
 }
 
-/* アラームの振動アニメーション */
+/* タイマー時間切れ時の振動アニメーション */
 @keyframes shake {
-  3%, 9%, 15%, 21%, 27% { transform: rotate(-8deg); }
-  6%, 12%, 18%, 24%, 30% { transform: rotate(8deg); }
-  31%, 100% { transform: translateX(0); }
+  3%,
+  9%,
+  15%,
+  21%,
+  27% {
+    transform: rotate(-8deg);
+  }
+  6%,
+  12%,
+  18%,
+  24%,
+  30% {
+    transform: rotate(8deg);
+  }
+  31%,
+  100% {
+    transform: translateX(0);
+  }
 }
+
 .shake-animation {
   animation: shake 1s ease-in-out infinite;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,25 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
+
+/**
+ * ルートレイアウト（サーバーコンポーネント）
+ *
+ * メタデータ・背景・全体の土台のみを担当し、
+ * カード UI 本体は page.tsx 側のクライアントコンポーネントで描画します。
+ */
 
 export const metadata: Metadata = {
   title: "Game Tools!",
   description: "For board games, card games, and more! Streamer friendly!",
+  manifest: "/manifest.json",
+  icons: {
+    icon: "/favicon.ico",
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({
@@ -13,20 +29,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
-      <head>
-        <meta charSet="utf-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link rel="icon" href="/favicon.ico" />
-        <link rel="manifest" href="./manifest.json" />
-      </head>
-      <body
-        className={`relative antialiased h-screen select-none overflow-x-hidden overflow-y-hidden`}
-      >
+      <body className="relative antialiased h-screen select-none overflow-hidden">
         {/* SP はカードが全面を覆うため背景画像を読み込まない（~800KB 削減） */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src="/okumono_moku14.png"
           alt=""
-          className="absolute h-full w-full z-[-10] object-cover hidden min-[500px]:block"
+          className="absolute inset-0 z-[-10] h-full w-full object-cover hidden min-[500px]:block"
           decoding="async"
         />
         {children}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,24 +1,35 @@
 "use client";
 
+/**
+ * エントリページ
+ *
+ * 画面幅 500px 未満を SP とし、GridSP / Grid を切り替えて表示します。
+ * Three.js を含むため、両 Grid は SSR 無効の dynamic import です。
+ */
+
 import { useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import ErrorBoundary from "@/components/ErrorBoundary";
 
-const Grid = dynamic(() => import("../components/Grid"), {
+const Grid = dynamic(() => import("@/components/Grid"), {
   ssr: false,
   loading: () => <div className="w-full h-dvh" />,
 });
-const GridSP = dynamic(() => import("../components/GridSP"), {
+
+const GridSP = dynamic(() => import("@/components/GridSP"), {
   ssr: false,
   loading: () => <div className="w-full h-dvh" />,
 });
+
+/** SP / PC の切り替え幅（px） */
+const SP_BREAKPOINT = 500;
 
 export default function App() {
   const [isSP, setIsSP] = useState<boolean | null>(null);
 
   useEffect(() => {
     const handleResize = () => {
-      setIsSP(window.innerWidth < 500);
+      setIsSP(window.innerWidth < SP_BREAKPOINT);
     };
     handleResize();
     window.addEventListener("resize", handleResize);

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,50 +1,66 @@
-import React, { Component, ReactNode } from "react";
+"use client";
 
-class ErrorBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
-    constructor(props: { children: ReactNode }) {
-        super(props);
-        this.state = { hasError: false };
+/**
+ * ランタイムエラーを捕捉し、リカバリ UI を表示する境界コンポーネント
+ *
+ * 破損したローカルストレージ等が原因のことが多いため、
+ * エラー時は localStorage をクリアして再読み込みを促します。
+ */
+
+import { Component, type ReactNode } from "react";
+
+type Props = { children: ReactNode };
+type State = { hasError: boolean };
+
+export default class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary がエラーを捕捉しました:", error, errorInfo);
+
+    try {
+      localStorage.clear();
+    } catch {
+      // Private Mode などでは clear に失敗することがある
+    }
+  }
+
+  handleReload = () => {
+    try {
+      localStorage.clear();
+    } catch {
+      // ignore
+    }
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center h-screen bg-gray-700 gap-8">
+          <h1 className="text-2xl text-center text-white">
+            Error occurred.
+            <br />
+            Please reload the page.
+          </h1>
+          <button
+            type="button"
+            onClick={this.handleReload}
+            className="text-3xl p-4 text-center rounded-md cursor-pointer duration-200 hover:opacity-70 text-white bg-red-500"
+          >
+            Reload
+          </button>
+        </div>
+      );
     }
 
-    static getDerivedStateFromError() {
-        // エラーが発生した場合に状態を更新
-        return { hasError: true };
-    }
-
-    componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-        // エラー情報をログに出力
-        console.error("Error!!:", error, errorInfo);
-        console.warn("Error message:", error.message);
-
-        // エラーが発生した場合にローカルストレージを削除
-        console.log("Delete localStorage");
-        localStorage.clear();
-    }
-
-    render() {
-        if (this.state.hasError) {
-            // エラー発生時に表示するUI
-            return (
-                <div className="flex flex-col items-center justify-center h-screen bg-gray-700 gap-8">
-                    <h1 className="text-2xl text-center text-white" >
-                        Error occurred. <br/>Please reload the page🙇
-                    </h1>
-                    <div
-                        onClick={() => {
-                            localStorage.clear(); // ローカルストレージを削除
-                            window.location.reload(); // ページをリロードして初期状態に戻す
-                        }}
-                        className="text-3xl p-4 text-center rounded-md cursor-pointer duration-200 hover:opacity-70 text-white bg-red-500"
-                    >
-                        Reload
-                    </div>
-                </div>
-
-            );
-        }
-
-        return this.props.children;
-    }
+    return this.props.children;
+  }
 }
-
-export default ErrorBoundary;

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -1,158 +1,172 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
-import { cardMap, maxRange, initialCardsList, initialStyle, initialPlayers, fonts } from "../utils/cardDefinitions";
-import { setInitialCardsList, useDragDrop, calculateAndUpdateGrid } from "../utils/cardFuncs";
-import { getLocalStorage, setLocalStorage } from "../utils/localFuncs";
-import DragIcon from "../components/card/module/DragIcon";
-import CloseButton from "../components/card/module/CloseButton";
-import Setter from "../components/Setter";
+/**
+ * PC 向けグリッド表示
+ *
+ * カードを 224px マスの絶対配置で並べ、ドラッグ＆ドロップで入れ替えできます。
+ * 空きマスには Setter（＋ボタン）を表示します。
+ */
 
-// ======================================================================
-// 定数定義
-// ======================================================================
-const initialCardsListFilled = setInitialCardsList(initialCardsList, maxRange.rows, maxRange.cols);
+import { useState, useEffect, useRef } from "react";
+import {
+  cardMap,
+  maxRange,
+  initialCardsList,
+  initialStyle,
+  initialPlayers,
+  fonts,
+} from "@/utils/cardDefinitions";
+import {
+  fillEmptySlotsWithSetter,
+  useDragDrop,
+  calculateAndUpdateGrid,
+  CARD_SIZE_PX,
+} from "@/utils/cardFuncs";
+import { getLocalJson, setLocalStorage } from "@/utils/localFuncs";
+import type { CardSetting, CardStyle, Player } from "@/utils/types";
+import DragIcon from "@/components/card/module/DragIcon";
+import CloseButton from "@/components/card/module/CloseButton";
+import Setter from "@/components/Setter";
+
+/** setter で埋めた初期カードリスト（ローカル未保存時のデフォルト） */
+const initialCardsListFilled = fillEmptySlotsWithSetter(
+  initialCardsList,
+  maxRange.rows,
+  maxRange.cols
+);
 
 export default function Grid() {
-  // ======================================================================
-  // ステート定義
-  // ======================================================================
-  const [cardList, setCardList] = useState(initialCardsListFilled); // カードリスト
-  const [cardStyle, setCardStyle] = useState(initialStyle); // スタイル設定
-  const [zoomRatio, setZoomRatio] = useState(1); // ズーム倍率
-  const [viewRange, setViewRange] = useState({ x: maxRange.cols, y: maxRange.rows }); // 表示範囲
-  const [players, setPlayers] = useState(initialPlayers); // プレイヤーデータ
-  const [dragIndex, setDragIndex] = useState<number | null>(null); // ドラッグ中のカードのインデックス
-  const [dragOffset, setDragOffset] = useState<{ x: number; y: number } | null>( // ドラッグ中のカードのオフセット
+  const [cardList, setCardList] = useState<CardSetting[]>(initialCardsListFilled);
+  const [cardStyle, setCardStyle] = useState<CardStyle>(initialStyle);
+  const [zoomRatio, setZoomRatio] = useState(1);
+  const [viewRange, setViewRange] = useState({
+    x: maxRange.cols,
+    y: maxRange.rows,
+  });
+  const [players, setPlayers] = useState<Player[]>(initialPlayers);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOffset, setDragOffset] = useState<{ x: number; y: number } | null>(
     null
   );
 
-  // ======================================================================
-  // リファレンス定義
-  // ======================================================================
   const cardListRef = useRef(cardList);
   useEffect(() => {
     cardListRef.current = cardList;
   }, [cardList]);
 
-  // ======================================================================
-  // ドラッグ＆ドロップ処理
-  // ======================================================================
   const { handleDragStart, handleDragOver, handleDrop } = useDragDrop(
-    setDragIndex, setDragOffset, dragIndex, dragOffset, cardList, setCardList
+    setDragIndex,
+    setDragOffset,
+    dragIndex,
+    dragOffset,
+    cardList,
+    setCardList
   );
 
-  // ======================================================================
-  // useEffect
-  // ======================================================================
-  // グリッドの列数、行数、ズーム倍率を更新するための useEffect
+  // リサイズに応じて列数・行数・ズーム倍率を更新
   useEffect(() => {
     const handleResize = () => {
-      const { zoomRatio, cols, rows } = calculateAndUpdateGrid(window.outerWidth, window.innerWidth);
-      setZoomRatio(zoomRatio);
+      const { zoomRatio: nextZoom, cols, rows } = calculateAndUpdateGrid(
+        window.outerWidth,
+        window.innerWidth
+      );
+      setZoomRatio(nextZoom);
       setViewRange({ x: cols, y: rows });
     };
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
-  }, []); // 初回のみ実行
-
-  // 一部プロパティをローカルストレージからステートへ読み込む useEffect
-  useEffect(() => {
-    const cardListStorage = getLocalStorage("cardList");
-    const cardStyleStorage = getLocalStorage("cardStyle");
-    const playersStorage = getLocalStorage("players");
-    // SP 保存分に setter が無い場合もあるため、空きマスを setter で埋めてから使う
-    setCardList(
-      cardListStorage
-        ? setInitialCardsList(JSON.parse(cardListStorage), maxRange.rows, maxRange.cols)
-        : initialCardsListFilled
-    );
-    setCardStyle(cardStyleStorage ? JSON.parse(cardStyleStorage) : initialStyle);
-    setPlayers(playersStorage ? JSON.parse(playersStorage) : initialPlayers);
   }, []);
 
-  // カードリスト変更、カードスタイル変更をローカルストレージに保存する useEffect
+  // 初回マウント時にローカルストレージから復元
+  // SP 保存分には setter が無い場合があるため、空きマスを埋めてから使う
+  useEffect(() => {
+    const storedList = getLocalJson<CardSetting[] | null>("cardList", null);
+    setCardList(
+      storedList
+        ? fillEmptySlotsWithSetter(storedList, maxRange.rows, maxRange.cols)
+        : initialCardsListFilled
+    );
+    setCardStyle(getLocalJson("cardStyle", initialStyle));
+    setPlayers(getLocalJson("players", initialPlayers));
+  }, []);
+
+  // 変更をローカルストレージへ保存（初期値のままならスキップ）
   useEffect(() => {
     if (cardList === initialCardsListFilled) return;
     setLocalStorage("cardList", JSON.stringify(cardList));
   }, [cardList]);
+
   useEffect(() => {
     if (cardStyle === initialStyle) return;
     setLocalStorage("cardStyle", JSON.stringify(cardStyle));
   }, [cardStyle]);
 
-  // ======================================================================
-  // レンダリング
-  // ======================================================================
+  const fontClass = fonts[cardStyle.fontStyle - 1]?.className ?? "";
+
   return (
-    <>
-      <div
-        className={"relative w-full h-full " + fonts[cardStyle.fontStyle - 1].className}
-        id="card-container"
-        onDragOver={handleDragOver}
-        onDrop={handleDrop}
-        style={{
-          zoom: zoomRatio,
-        }}
-      >
-        {cardList.map((item, index) => {
-          // 表示範囲外のカードはレンダリングしない
-          if (item.x >= viewRange.x || item.y >= viewRange.y) return null;
+    <div
+      className={`relative w-full h-full ${fontClass}`}
+      id="card-container"
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+      style={{ zoom: zoomRatio }}
+    >
+      {cardList.map((item, index) => {
+        // 表示範囲外は描画しない（パフォーマンス）
+        if (item.x >= viewRange.x || item.y >= viewRange.y) return null;
 
-          // 背景色、フォント色を設定
-          const isEven = (item.x + item.y) % 2 === 0;
-          const bgColor = isEven ? cardStyle.bgColor_1 : cardStyle.bgColor_2;
-          const fontColor = isEven ? cardStyle.fontColor_1 : cardStyle.fontColor_2;
-          const Component = cardMap[item.component];
+        const isEven = (item.x + item.y) % 2 === 0;
+        const bgColor = isEven ? cardStyle.bgColor_1 : cardStyle.bgColor_2;
+        const fontColor = isEven
+          ? cardStyle.fontColor_1
+          : cardStyle.fontColor_2;
+        const Component = cardMap[item.component];
 
-          return (
-            <div key={`${item.x}-${item.y}`}>
-              {item.component === "setter" ? (
-                // Setter カードのみ特殊呼び出し
-                <Setter
-                  item={item}
-                  cardMap={cardMap}
-                  cardList={cardList}
-                  setCardList={setCardList}
-                  bgColor={bgColor}
+        return (
+          <div key={`${item.x}-${item.y}`}>
+            {item.component === "setter" || !Component ? (
+              <Setter
+                item={item}
+                cardMap={cardMap}
+                cardList={cardList}
+                setCardList={setCardList}
+                bgColor={bgColor}
+                fontColor={fontColor}
+              />
+            ) : (
+              <div
+                className="absolute w-56 h-56 text-center"
+                style={{
+                  backgroundColor: bgColor,
+                  color: fontColor,
+                  left: item.x * CARD_SIZE_PX,
+                  top: item.y * CARD_SIZE_PX,
+                }}
+              >
+                <DragIcon
+                  index={index}
+                  handleDragStart={handleDragStart}
                   fontColor={fontColor}
                 />
-              ) : (
-                <div
-                  className={"absolute w-56 h-56 text-center"}
-                  style={{
-                    backgroundColor: bgColor,
-                    color: fontColor,
-                    left: item.x * 224, // 224 は カードの幅
-                    top: item.y * 224, // 224 は カードの幅
-                  }}
-                >
-                  <DragIcon
-                    index={index}
-                    handleDragStart={handleDragStart}
-                    fontColor={fontColor}
-                  />
-                  <CloseButton
-                    index={index}
-                    cardList={cardList}
-                    setCardList={setCardList}
-                  />
-                  {/* カードの中身 */}
-                  <Component
-                    zoomRatio={zoomRatio}
-                    players={players}
-                    setPlayers={setPlayers}
-                    cardStyle={cardStyle}
-                    setCardStyle={setCardStyle}
-                    setCardList={setCardList}
-                  />
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </>
+                <CloseButton
+                  index={index}
+                  cardList={cardList}
+                  setCardList={setCardList}
+                />
+                <Component
+                  zoomRatio={zoomRatio}
+                  players={players}
+                  setPlayers={setPlayers}
+                  cardStyle={cardStyle}
+                  setCardStyle={setCardStyle}
+                  setCardList={setCardList}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/components/Grid.tsx
+++ b/components/Grid.tsx
@@ -39,7 +39,7 @@ export default function Grid() {
   const [cardList, setCardList] = useState<CardSetting[]>(initialCardsListFilled);
   const [cardStyle, setCardStyle] = useState<CardStyle>(initialStyle);
   const [zoomRatio, setZoomRatio] = useState(1);
-  const [viewRange, setViewRange] = useState({
+  const [viewRange, setViewRange] = useState<{ x: number; y: number }>({
     x: maxRange.cols,
     y: maxRange.rows,
   });

--- a/components/GridSP.tsx
+++ b/components/GridSP.tsx
@@ -1,13 +1,36 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback, useMemo, memo } from "react";
-import { cardMap, initialCardsList, initialStyle, initialPlayers, fonts } from "../utils/cardDefinitions";
-import { getLocalStorage, setLocalStorage } from "../utils/localFuncs";
+/**
+ * スマートフォン向けカード表示
+ *
+ * 横スワイプでカードを切り替えます。
+ * 描画負荷を抑えるため、現在・前後のカードのみ表示し、
+ * 3D カードはアクティブ時だけ Canvas を起動します。
+ */
+
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo,
+  memo,
+} from "react";
+import {
+  cardMap,
+  initialCardsList,
+  initialStyle,
+  initialPlayers,
+  fonts,
+} from "@/utils/cardDefinitions";
+import { getLocalJson, setLocalStorage } from "@/utils/localFuncs";
 import { calculateAndUpdateGrid } from "@/utils/cardFuncs";
 import type { CardSetting, CardStyle, Player } from "@/utils/types";
 
-const cardTransitionThreshold = 80; // スワイプの閾値
-const swipeEffectThreshold = 50; // スワイプの遊び閾値
+/** スワイプでページ送りと判定する移動量（px） */
+const CARD_TRANSITION_THRESHOLD = 80;
+/** スワイプ演出を開始する遊び（px） */
+const SWIPE_EFFECT_THRESHOLD = 50;
 
 type CardContentProps = {
   card: CardSetting;
@@ -22,7 +45,7 @@ type CardContentProps = {
   fontColor: string;
 };
 
-/** スワイプ中も再レンダーされないカード本体 */
+/** スワイプ中も再レンダーされないカード本体（memo 化） */
 const CardContent = memo(function CardContent({
   card,
   isActive,
@@ -35,7 +58,8 @@ const CardContent = memo(function CardContent({
   bgColor,
   fontColor,
 }: CardContentProps) {
-  const Component = cardMap[card.component] || (() => <div>Component not found</div>);
+  const Component =
+    cardMap[card.component] ?? (() => <div>Component not found</div>);
 
   return (
     <div
@@ -43,7 +67,7 @@ const CardContent = memo(function CardContent({
       style={{ backgroundColor: bgColor, color: fontColor }}
     >
       <div
-        className="absolute top-1/2 left-1/2 w-56 h-56 transform -translate-x-1/2 -translate-y-1/2"
+        className="absolute top-1/2 left-1/2 w-56 h-56 -translate-x-1/2 -translate-y-1/2"
         style={{ zoom: zoomRatio }}
       >
         <Component
@@ -61,12 +85,9 @@ const CardContent = memo(function CardContent({
 });
 
 export default function GridSP() {
-  // ======================================================================
-  // ステート定義
-  // ======================================================================
-  const [cardList, setCardList] = useState(initialCardsList);
-  const [cardStyle, setCardStyle] = useState(initialStyle);
-  const [players, setPlayers] = useState(initialPlayers);
+  const [cardList, setCardList] = useState<CardSetting[]>(initialCardsList);
+  const [cardStyle, setCardStyle] = useState<CardStyle>(initialStyle);
+  const [players, setPlayers] = useState<Player[]>(initialPlayers);
   const [zoomRatio, setZoomRatio] = useState(1);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [swipeOffset, setSwipeOffset] = useState(0);
@@ -85,46 +106,47 @@ export default function GridSP() {
     isAnimatingRef.current = isAnimating;
   }, [isAnimating]);
 
-  // グリッドのズーム倍率を更新
+  // ズーム倍率を画面幅に追従
   useEffect(() => {
     const handleResize = () => {
-      const { zoomRatio } = calculateAndUpdateGrid(window.outerWidth, window.innerWidth);
-      setZoomRatio(zoomRatio);
+      const { zoomRatio: nextZoom } = calculateAndUpdateGrid(
+        window.outerWidth,
+        window.innerWidth
+      );
+      setZoomRatio(nextZoom);
     };
     handleResize();
     window.addEventListener("resize", handleResize);
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  // ローカルストレージから読み込み
+  // ローカルストレージから復元
   useEffect(() => {
-    const cardListStorage = getLocalStorage("cardList");
-    const cardStyleStorage = getLocalStorage("cardStyle");
-    const playersStorage = getLocalStorage("players");
-    setCardList(cardListStorage ? JSON.parse(cardListStorage) : initialCardsList);
-    setCardStyle(cardStyleStorage ? JSON.parse(cardStyleStorage) : initialStyle);
-    setPlayers(playersStorage ? JSON.parse(playersStorage) : initialPlayers);
+    setCardList(getLocalJson("cardList", initialCardsList));
+    setCardStyle(getLocalJson("cardStyle", initialStyle));
+    setPlayers(getLocalJson("players", initialPlayers));
   }, []);
 
-  // setter カードを除去
+  // PC 由来の setter カードは SP では不要なので除去
   useEffect(() => {
-    const newCardList = cardList.filter((card) => card.component !== "setter");
-    if (newCardList.length !== cardList.length) {
-      setCardList(newCardList);
+    const withoutSetter = cardList.filter((card) => card.component !== "setter");
+    if (withoutSetter.length !== cardList.length) {
+      setCardList(withoutSetter);
     }
   }, [cardList]);
 
-  // ローカルストレージへ保存
+  // 変更を保存
   useEffect(() => {
     if (cardList === initialCardsList) return;
     setLocalStorage("cardList", JSON.stringify(cardList));
   }, [cardList]);
+
   useEffect(() => {
     if (cardStyle === initialStyle) return;
     setLocalStorage("cardStyle", JSON.stringify(cardStyle));
   }, [cardStyle]);
 
-  // スワイプハンドラ（タッチ座標は ref で持ち、再レンダーを抑制）
+  // タッチ座標は ref で持ち、移動中の不要な再レンダーを抑える
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     if (isAnimatingRef.current) return;
     const touch = e.touches[0];
@@ -139,12 +161,16 @@ export default function GridSP() {
     touchEndRef.current = { x: touch.clientX, y: touch.clientY };
     const deltaX = touch.clientX - touchStartRef.current.x;
 
-    if (Math.abs(deltaX) < swipeEffectThreshold) {
+    if (Math.abs(deltaX) < SWIPE_EFFECT_THRESHOLD) {
       setSwipeOffset(0);
       return;
     }
-    const effectiveDeltaX = (Math.abs(deltaX) - swipeEffectThreshold) * (deltaX > 0 ? 1 : -1);
-    const newOffset = Math.sqrt(Math.abs(effectiveDeltaX)) * 5 * (effectiveDeltaX > 0 ? 1 : -1);
+
+    // 遊びを除いた量を平方根スケールで視覚オフセットに変換
+    const effectiveDeltaX =
+      (Math.abs(deltaX) - SWIPE_EFFECT_THRESHOLD) * (deltaX > 0 ? 1 : -1);
+    const newOffset =
+      Math.sqrt(Math.abs(effectiveDeltaX)) * 5 * (effectiveDeltaX > 0 ? 1 : -1);
     setSwipeOffset(newOffset);
   }, []);
 
@@ -156,8 +182,8 @@ export default function GridSP() {
     const deltaX = touchEnd.x - touchStart.x;
     const width = window.innerWidth;
 
-    // タップ（閾値未満）はスワイプ処理しない → 3D の pointer イベントを邪魔しない
-    if (Math.abs(deltaX) < cardTransitionThreshold) {
+    // タップ（閾値未満）はスワイプ処理しない → 3D の pointer を邪魔しない
+    if (Math.abs(deltaX) < CARD_TRANSITION_THRESHOLD) {
       setSwipeOffset(0);
       touchStartRef.current = null;
       touchEndRef.current = null;
@@ -167,11 +193,12 @@ export default function GridSP() {
     setIsAnimating(true);
     isAnimatingRef.current = true;
 
-    if (deltaX > cardTransitionThreshold) {
+    if (deltaX > CARD_TRANSITION_THRESHOLD) {
       setSwipeOffset(width * 0.3);
       setTimeout(() => {
-        setCurrentIndex((prevIndex) =>
-          (prevIndex - 1 + cardListRef.current.length) % cardListRef.current.length
+        setCurrentIndex(
+          (prev) =>
+            (prev - 1 + cardListRef.current.length) % cardListRef.current.length
         );
         setSwipeOffset(0);
         setIsAnimating(false);
@@ -180,7 +207,9 @@ export default function GridSP() {
     } else {
       setSwipeOffset(-width * 0.3);
       setTimeout(() => {
-        setCurrentIndex((prevIndex) => (prevIndex + 1) % cardListRef.current.length);
+        setCurrentIndex(
+          (prev) => (prev + 1) % cardListRef.current.length
+        );
         setSwipeOffset(0);
         setIsAnimating(false);
         isAnimatingRef.current = false;
@@ -197,7 +226,9 @@ export default function GridSP() {
         {cardList.map((_, i) => (
           <div
             key={i}
-            className={`w-2 h-2 mx-1 rounded-full ${i === currentIndex ? "bg-white" : "bg-gray-400"}`}
+            className={`w-2 h-2 mx-1 rounded-full ${
+              i === currentIndex ? "bg-white" : "bg-gray-400"
+            }`}
           />
         ))}
       </div>
@@ -205,46 +236,47 @@ export default function GridSP() {
     [cardList, currentIndex]
   );
 
-  const cardColors = useMemo(() => {
-    return cardList.map((_, index) => {
-      const isEven = index % 2 === 0;
-      return {
-        bgColor: isEven ? cardStyle.bgColor_1 : cardStyle.bgColor_2,
-        fontColor: isEven ? cardStyle.fontColor_1 : cardStyle.fontColor_2,
-      };
-    });
-  }, [cardList, cardStyle]);
+  const cardColors = useMemo(
+    () =>
+      cardList.map((_, index) => {
+        const isEven = index % 2 === 0;
+        return {
+          bgColor: isEven ? cardStyle.bgColor_1 : cardStyle.bgColor_2,
+          fontColor: isEven ? cardStyle.fontColor_1 : cardStyle.fontColor_2,
+        };
+      }),
+    [cardList, cardStyle]
+  );
 
-  // 現在・前後カードのみ表示。本体は memo 化しているためスワイプ中はシェルだけ更新される
+  // 現在・前後カードのみ表示。本体は memo 化しているためスワイプ中はシェルだけ更新
   const cards = useMemo(() => {
     const len = cardList.length;
     if (len === 0) return null;
 
     return cardList.map((card, index) => {
       const positionDiff = index - currentIndex;
-      const normalizedPositionDiff = ((positionDiff % len) + len) % len;
+      const normalized = ((positionDiff % len) + len) % len;
 
       let translateX = 0;
       let zIndex = 0;
       let visible = false;
 
-      if (normalizedPositionDiff === 0) {
+      if (normalized === 0) {
         translateX = swipeOffset;
         zIndex = 2;
         visible = true;
-      } else if (normalizedPositionDiff === len - 1) {
+      } else if (normalized === len - 1) {
         translateX = -100 + swipeOffset;
         zIndex = 1;
         visible = true;
-      } else if (normalizedPositionDiff === 1) {
+      } else if (normalized === 1) {
         translateX = 100 + swipeOffset;
         zIndex = 1;
         visible = true;
       }
 
       // 表示中カードのみ WebGL を起動（同時 Canvas を 1 つに抑える）
-      const isActive = normalizedPositionDiff === 0;
-
+      const isActive = normalized === 0;
       const colors = cardColors[index];
 
       return (
@@ -255,10 +287,9 @@ export default function GridSP() {
             transform: `translate3d(${translateX}%, 0, 0)`,
             transition: isAnimating ? "transform 0.1s ease-out" : "none",
             zIndex,
-            // display:none だと再表示時のコストが大きいので、非表示は visibility + 画面外へ
+            // display:none は再表示コストが大きいので visibility + 画面外で隠す
             visibility: visible ? "visible" : "hidden",
             pointerEvents: visible ? "auto" : "none",
-            // 非表示カードはレイアウト計算を抑える
             contentVisibility: visible ? "visible" : "hidden",
             willChange: visible ? "transform" : "auto",
           }}
@@ -289,9 +320,11 @@ export default function GridSP() {
     cardColors,
   ]);
 
+  const fontClass = fonts[cardStyle.fontStyle - 1]?.className ?? "";
+
   return (
     <div
-      className={"relative w-full h-dvh overflow-hidden " + fonts[cardStyle.fontStyle - 1].className}
+      className={`relative w-full h-dvh overflow-hidden ${fontClass}`}
       onTouchStart={handleTouchStart}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}

--- a/components/Setter.tsx
+++ b/components/Setter.tsx
@@ -1,84 +1,96 @@
 "use client";
 
-import { useState } from "react";
-import { CardComponent, CardSetting } from "../utils/types";
+/**
+ * 空きマス用のカード追加 UI
+ *
+ * ホバーで「＋」を出し、クリックで追加可能なカード一覧を表示します。
+ * ＋と一覧を同じホバー領域に置くことで、
+ * 一覧表示直後に mouseLeave で消えてしまう問題を防いでいます。
+ */
 
-export default function Setter(props: {
+import { useState } from "react";
+import type { CardComponent, CardSetting } from "@/utils/types";
+import { CARD_SIZE_PX } from "@/utils/cardFuncs";
+
+type SetterProps = {
   item: CardSetting;
-  cardMap: { [key: string]: CardComponent };
+  cardMap: Record<string, CardComponent>;
   cardList: CardSetting[];
-  setCardList: (arg: CardSetting[]) => void;
+  setCardList: (list: CardSetting[]) => void;
   bgColor: string;
   fontColor: string;
-}) {
-  const { item, cardMap, cardList, setCardList, bgColor, fontColor } = props;
+};
 
+export default function Setter({
+  item,
+  cardMap,
+  cardList,
+  setCardList,
+  bgColor,
+  fontColor,
+}: SetterProps) {
   // none: 非表示 / button: ＋ボタン / list: カード選択一覧
-  const [setterDisplay, setSetterDisplay] = useState<"none" | "button" | "list">("none");
+  const [display, setDisplay] = useState<"none" | "button" | "list">("none");
 
-  const handleClick = (key: string) => {
+  const handleSelect = (key: string) => {
     setCardList(
-      cardList.map((c) =>
-        c.x === item.x && c.y === item.y
+      cardList.map((card) =>
+        card.x === item.x && card.y === item.y
           ? { component: key, x: item.x, y: item.y }
-          : c
+          : card
       )
     );
-    setSetterDisplay("none");
+    setDisplay("none");
   };
 
-  if (!cardMap || !cardList) {
-    return null;
-  }
+  /** camelCase を改行付き表示用に整形（例: oneOnOne → One\nOn\nOne） */
+  const formatKey = (key: string) =>
+    key
+      .replace(/([a-z])([A-Z])/g, "$1\n$2")
+      .replace(/^./, (c) => c.toUpperCase());
 
   const componentKeys = Object.keys(cardMap);
-
-  const formatKey = (key: string) => {
-    return key.replace(/([a-z])([A-Z])/g, "$1\n$2");
-  };
 
   return (
     <div className="relative">
       <div
         className="absolute w-56 h-56 text-center"
         style={{
-          left: item.x * 224,
-          top: item.y * 224,
+          left: item.x * CARD_SIZE_PX,
+          top: item.y * CARD_SIZE_PX,
           color: fontColor,
         }}
-        // ＋と一覧を同じホバー領域に置く。
-        // 以前は一覧が領域外だったため、＋クリック直後に mouseLeave で list が消えていた。
         onMouseEnter={() =>
-          setSetterDisplay((prev) => (prev === "none" ? "button" : prev))
+          setDisplay((prev) => (prev === "none" ? "button" : prev))
         }
-        onMouseLeave={() => setSetterDisplay("none")}
+        onMouseLeave={() => setDisplay("none")}
       >
-        {setterDisplay === "button" && (
+        {display === "button" && (
           <button
+            type="button"
             className="w-full h-full text-6xl backdrop-brightness-75 border-2 border-dashed duration-200"
-            onClick={() => setSetterDisplay("list")}
-            style={{
-              borderColor: fontColor,
-            }}
+            style={{ borderColor: fontColor }}
+            onClick={() => setDisplay("list")}
           >
             +
           </button>
         )}
-        {setterDisplay === "list" && (
+        {display === "list" && (
           <div className="w-full h-full grid grid-cols-4 grid-rows-4">
-            {componentKeys.map((key, index) => (
+            {componentKeys.map((key) => (
               <button
-                key={index}
-                className="flex items-center justify-center text-xs duration-200 hover:brightness-150"
-                onClick={() => handleClick(key)}
+                type="button"
+                key={key}
+                className="flex items-center justify-center text-xs duration-200 hover:brightness-150 whitespace-pre-line"
                 style={{
                   backgroundColor: bgColor,
                   borderColor: fontColor,
                   borderWidth: 1,
                   borderStyle: "dashed",
                 }}
+                onClick={() => handleSelect(key)}
               >
-                {formatKey(key.charAt(0).toUpperCase() + key.slice(1))}
+                {formatKey(key)}
               </button>
             ))}
           </div>

--- a/components/card/Coin.tsx
+++ b/components/card/Coin.tsx
@@ -1,15 +1,21 @@
 "use client";
 
+/**
+ * 3D コインカード
+ *
+ * タップでフリップ開始・停止。停止時に表裏どちらかへスナップします。
+ */
+
 import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
 import { useMemo, useRef, useCallback } from "react";
 import { Group } from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 
-const modelPath = "Coin.glb";
+const MODEL_PATH = "Coin.glb";
 
 function CoinModel() {
-  const { scene } = useGLTF(modelPath);
+  const { scene } = useGLTF(MODEL_PATH);
   const clonedScene = useMemo(() => scene.clone(), [scene]);
 
   return (
@@ -21,7 +27,7 @@ function CoinModel() {
   );
 }
 
-function GroupComponent() {
+function CoinGroup() {
   const groupRef = useRef<Group>(null);
   const isFlippingRef = useRef(false);
   const isFlippingLastRef = useRef(false);
@@ -35,6 +41,7 @@ function GroupComponent() {
         group.rotation.x += (Math.PI * 15) / 100;
       }
     } else {
+      // 表裏のどちらか（π の奇数倍 / 偶数倍）へスナップ
       group.rotation.x = (Math.floor(Math.random() * 2) + 1) * Math.PI;
       isFlippingLastRef.current = isFlippingRef.current;
     }
@@ -48,7 +55,7 @@ function GroupComponent() {
   return (
     <group
       ref={groupRef}
-      rotation={[(2 * Math.PI) / 2, (2 * Math.PI) / 2, (2 * Math.PI) / 2]}
+      rotation={[Math.PI, Math.PI, Math.PI]}
       onPointerDown={handlePointerDown}
     >
       <CoinModel />
@@ -56,32 +63,31 @@ function GroupComponent() {
   );
 }
 
-export default function Coin(props: { zoomRatio: number; isActive?: boolean }) {
-  const { zoomRatio, isActive = true } = props;
-
+export default function Coin({
+  zoomRatio = 1,
+  isActive = true,
+}: {
+  zoomRatio?: number;
+  isActive?: boolean;
+}) {
   return (
     <>
       {isActive ? (
         <Canvas
           className="h-full w-full"
-          camera={{
-            fov: 70,
-            position: [0, 0, 50],
-          }}
-          style={{
-            zoom: 1 / zoomRatio,
-          }}
+          camera={{ fov: 70, position: [0, 0, 50] }}
+          style={{ zoom: 1 / zoomRatio }}
           dpr={[1, 1.5]}
           gl={{ antialias: false, powerPreference: "low-power" }}
         >
-          <GroupComponent />
+          <CoinGroup />
           <OrbitControls
             minDistance={120}
             maxDistance={153}
-            minPolarAngle={(Math.PI * -0) / 100}
-            maxPolarAngle={(Math.PI * 0) / 100}
-            minAzimuthAngle={(Math.PI * -0) / 100}
-            maxAzimuthAngle={(Math.PI * 0) / 100}
+            minPolarAngle={0}
+            maxPolarAngle={0}
+            minAzimuthAngle={0}
+            maxAzimuthAngle={0}
             enableRotate={false}
             enableZoom={false}
             enablePan={false}

--- a/components/card/Dice.tsx
+++ b/components/card/Dice.tsx
@@ -1,39 +1,36 @@
 "use client";
 
+/**
+ * 3D ダイスカード（6 面 / 20 面）
+ *
+ * タップで回転開始・停止。停止時にランダムな出目向きへスナップします。
+ * SP では isActive が false のとき Canvas を破棄し、WebGL 負荷を抑えます。
+ */
+
 import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls, useGLTF } from "@react-three/drei";
 import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import { Euler, Group } from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 
-// ==============================
-// 型定義
-// ==============================
 type DiceDimensions = "d6" | "d20";
 
 type DiceConfig = {
   modelPath: string;
-  scale: number[];
+  scale: [number, number, number];
   minDistance: number;
   maxDistance: number;
   minPolarAngle: number;
   maxPolarAngle: number;
   minAzimuthAngle: number;
   maxAzimuthAngle: number;
-  position: number[];
+  position: [number, number, number];
   maxValue: number;
   eulers: Euler[];
 };
 
-interface DiceTypes {
-  d6: DiceConfig;
-  d20: DiceConfig;
-}
-
-// ==============================
-// 設定
-// ==============================
-const diceTypes: DiceTypes = {
+/** ダイス種別ごとのモデル・カメラ制限・出目オイラー角 */
+const diceTypes: Record<DiceDimensions, DiceConfig> = {
   d6: {
     modelPath: "Dice_6.glb",
     scale: [100, 100, 100],
@@ -90,10 +87,14 @@ const diceTypes: DiceTypes = {
   },
 };
 
-// ==============================
-// カスタムフック - ダイスロジック（ref 更新で React 再レンダーを回避）
-// ==============================
-function useDiceLogic(diceType: DiceDimensions, groupRef: React.RefObject<Group | null>) {
+/**
+ * ダイス回転ロジック（ref 更新で React 再レンダーを回避）
+ * 回転中は毎フレーム姿勢を進め、停止時に出目オイラーへコピーします。
+ */
+function useDiceLogic(
+  diceType: DiceDimensions,
+  groupRef: React.RefObject<Group | null>
+) {
   const isRollingRef = useRef(false);
   const isRollingLastRef = useRef(false);
 
@@ -113,7 +114,9 @@ function useDiceLogic(diceType: DiceDimensions, groupRef: React.RefObject<Group 
         group.rotation.z += (Math.PI * 15) / 100;
       }
     } else {
-      const randomIndex = Math.floor(Math.random() * diceTypes[diceType].maxValue);
+      const randomIndex = Math.floor(
+        Math.random() * diceTypes[diceType].maxValue
+      );
       group.rotation.copy(diceTypes[diceType].eulers[randomIndex]);
       isRollingLastRef.current = isRollingRef.current;
     }
@@ -122,13 +125,11 @@ function useDiceLogic(diceType: DiceDimensions, groupRef: React.RefObject<Group 
   return { rollDice };
 }
 
-// ==============================
-// ダイスモデルコンポーネント
-// ==============================
 function DiceModel({ diceType }: { diceType: DiceDimensions }) {
   const { scene } = useGLTF(diceTypes[diceType].modelPath);
   const clonedScene = useMemo(() => scene?.clone(), [scene]);
   const config = diceTypes[diceType];
+
   return (
     <primitive
       object={clonedScene}
@@ -138,9 +139,6 @@ function DiceModel({ diceType }: { diceType: DiceDimensions }) {
   );
 }
 
-// ==============================
-// グループコンポーネント
-// ==============================
 function DiceGroup({ diceType }: { diceType: DiceDimensions }) {
   const groupRef = useRef<Group>(null);
   const { rollDice } = useDiceLogic(diceType, groupRef);
@@ -158,12 +156,15 @@ function DiceGroup({ diceType }: { diceType: DiceDimensions }) {
   );
 }
 
-// ==============================
-// メインコンポーネント
-// ==============================
-export default function Dice(props: { zoomRatio: number; isActive?: boolean }) {
-  const { zoomRatio, isActive = true } = props;
-  const [selectedDiceType, setSelectedDiceType] = useState<DiceDimensions>("d6");
+export default function Dice({
+  zoomRatio = 1,
+  isActive = true,
+}: {
+  zoomRatio?: number;
+  isActive?: boolean;
+}) {
+  const [selectedDiceType, setSelectedDiceType] =
+    useState<DiceDimensions>("d6");
   const config = diceTypes[selectedDiceType];
 
   // アクティブ時のみ現在のモデルをプリロード（両方一括ロードしない）
@@ -186,7 +187,7 @@ export default function Dice(props: { zoomRatio: number; isActive?: boolean }) {
         <Canvas
           className="h-full w-full"
           style={{ zoom: 1 / zoomRatio }}
-          // 表示中 Canvas は常時描画（demand + KickFrame だとタップ後の反映漏れが起きる）
+          // demand + KickFrame だとタップ後の反映漏れが起きるため常時描画
           dpr={[1, 1.5]}
           gl={{ antialias: false, powerPreference: "low-power" }}
         >
@@ -211,9 +212,8 @@ export default function Dice(props: { zoomRatio: number; isActive?: boolean }) {
       )}
 
       <button
-        className={
-          "absolute z-10 block bottom-2 left-1/2 -translate-x-1/2 w-16 text-xl text-center duration-200 hover:opacity-80"
-        }
+        type="button"
+        className="absolute z-10 block bottom-2 left-1/2 -translate-x-1/2 w-16 text-xl text-center duration-200 hover:opacity-80"
         onClick={toggleDiceType}
       >
         {selectedDiceType}

--- a/components/card/Info.tsx
+++ b/components/card/Info.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-import { CardSetting } from "../../utils/types";
-import { initialCardsList } from "../../utils/cardDefinitions";
-import { setLocalStorage } from "../../utils/localFuncs";
+/**
+ * アプリ情報・カード配置リセット
+ *
+ * リンクと著作権表示、カード配置の初期化ボタンを提供します。
+ */
 
-export default function TurnCounter(props: {
-  setCardList: (arg: CardSetting[]) => void;
-}) {
-  const { setCardList } = props;
+import type { CardSetting } from "@/utils/types";
+import { initialCardsList } from "@/utils/cardDefinitions";
+import { setLocalStorage } from "@/utils/localFuncs";
 
+type InfoProps = {
+  setCardList?: (list: CardSetting[]) => void;
+};
+
+export default function Info({ setCardList }: InfoProps) {
   return (
     <div className="h-full flex flex-col justify-center items-center p-4">
       <div className="mt-4 flex items-center justify-center gap-x-2">
@@ -22,7 +28,7 @@ export default function TurnCounter(props: {
         </a>
         <div> / </div>
         <a
-          href="https://github.com/root-5/boardGameFan"
+          href="https://github.com/root-5/boardgamefan"
           target="_blank"
           rel="noopener noreferrer"
           className="text-xl duration-200 hover:opacity-70"
@@ -31,19 +37,20 @@ export default function TurnCounter(props: {
         </a>
       </div>
       <div className="flex flex-col items-center gap-1 mt-4 text-xs">
-        <p>Free for Everyone !</p>
-        <p>Use for anything !</p>
+        <p>Free for Everyone!</p>
+        <p>Use for anything!</p>
       </div>
       <button
+        type="button"
         onClick={() => {
-          setCardList(initialCardsList);
+          setCardList?.(initialCardsList);
           setLocalStorage("cardList", JSON.stringify(initialCardsList));
         }}
         className="mt-2 p-2 rounded-md duration-200 hover:bg-red-500"
       >
         Reset Cards
       </button>
-      <p className="mt-2 text-xs">© 2025 root-5</p>
+      <p className="mt-2 text-xs">© 2026 root-5</p>
     </div>
   );
 }

--- a/components/card/OneOnOne.tsx
+++ b/components/card/OneOnOne.tsx
@@ -1,123 +1,115 @@
 "use client";
 
-import { useState, useRef } from "react";
+/**
+ * 1 対 1 のポイントカウンター
+ *
+ * 左右それぞれのプレイヤーの点数を、入力・長押しで加減算します。
+ */
 
-const tokenMax = 99;
-const tokenMin = -99;
+import { useState } from "react";
+import { clamp } from "@/utils/clamp";
+import { useHoldRepeat } from "@/hooks/useHoldRepeat";
+import ResetButton from "@/components/card/module/ResetButton";
 
-function ajustTokenValue(value: number): number {
-  if (value > tokenMax) {
-    return tokenMax;
-  } else if (value < tokenMin) {
-    return tokenMin;
-  }
-  return value;
-}
+const POINT_MAX = 99;
+const POINT_MIN = -99;
 
 export default function OneOnOne() {
   const [player1Points, setPlayer1Points] = useState(0);
   const [player2Points, setPlayer2Points] = useState(0);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const { onHoldStart, onHoldEnd } = useHoldRepeat();
 
-  const handlePointChange = (player: number, adjustment: number) => {
-    if (player === 1) {
-      setPlayer1Points((prevPoints) => ajustTokenValue(prevPoints + adjustment));
-    } else {
-      setPlayer2Points((prevPoints) => ajustTokenValue(prevPoints + adjustment));
-    }
+  const adjustPlayer1 = (delta: number) => {
+    setPlayer1Points((prev) => clamp(prev + delta, POINT_MIN, POINT_MAX));
   };
 
-  const handleInputChange = (player: number, value: number) => {
-    if (player === 1) {
-      setPlayer1Points(ajustTokenValue(value));
-    } else {
-      setPlayer2Points(ajustTokenValue(value));
-    }
-  };
-
-  const handleMouseDown = (player: number, adjustment: number) => {
-    handlePointChange(player, adjustment);
-    intervalRef.current = setInterval(() => {
-      handlePointChange(player, adjustment);
-    }, 100);
-  };
-
-  const handleMouseUp = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
+  const adjustPlayer2 = (delta: number) => {
+    setPlayer2Points((prev) => clamp(prev + delta, POINT_MIN, POINT_MAX));
   };
 
   return (
     <div className="p-6">
-      <p className="text-[9px] opacity-50">
-        INPUT / ARROW KEY / SCROLL
-      </p>
+      <p className="text-[9px] opacity-50">INPUT / ARROW KEY / SCROLL</p>
       <div className="mt-2 flex justify-center items-center gap-2">
         <div className="flex flex-col justify-center items-center gap-1">
           <button
-            onMouseDown={() => handleMouseDown(1, 1)}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
+            type="button"
             className="text-3xl"
+            onMouseDown={() => onHoldStart(() => adjustPlayer1(1))}
+            onMouseUp={onHoldEnd}
+            onMouseLeave={onHoldEnd}
           >
             +
           </button>
           <input
             type="number"
             value={player1Points}
-            onChange={(e) => handleInputChange(1, parseInt(e.target.value))}
+            onChange={(e) =>
+              setPlayer1Points(
+                clamp(
+                  Number.parseInt(e.target.value, 10) || 0,
+                  POINT_MIN,
+                  POINT_MAX
+                )
+              )
+            }
             className="block w-20 text-5xl bg-transparent outline-none text-center"
           />
           <button
-            onMouseDown={() => handleMouseDown(1, -1)}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
+            type="button"
             className="text-3xl"
+            onMouseDown={() => onHoldStart(() => adjustPlayer1(-1))}
+            onMouseUp={onHoldEnd}
+            onMouseLeave={onHoldEnd}
           >
             -
           </button>
         </div>
-        <div
-          className="text-4xl"
-        >
-          -
-        </div>
+
+        <div className="text-4xl">-</div>
+
         <div className="flex flex-col justify-center items-center gap-1">
           <button
-            onMouseDown={() => handleMouseDown(2, 1)}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
+            type="button"
             className="text-3xl"
+            onMouseDown={() => onHoldStart(() => adjustPlayer2(1))}
+            onMouseUp={onHoldEnd}
+            onMouseLeave={onHoldEnd}
           >
             +
           </button>
           <input
             type="number"
             value={player2Points}
-            onChange={(e) => handleInputChange(2, parseInt(e.target.value))}
+            onChange={(e) =>
+              setPlayer2Points(
+                clamp(
+                  Number.parseInt(e.target.value, 10) || 0,
+                  POINT_MIN,
+                  POINT_MAX
+                )
+              )
+            }
             className="block w-20 text-5xl bg-transparent outline-none text-center"
-
           />
           <button
-            onMouseDown={() => handleMouseDown(2, -1)}
-            onMouseUp={handleMouseUp}
-            onMouseLeave={handleMouseUp}
+            type="button"
             className="text-3xl"
+            onMouseDown={() => onHoldStart(() => adjustPlayer2(-1))}
+            onMouseUp={onHoldEnd}
+            onMouseLeave={onHoldEnd}
           >
             -
           </button>
         </div>
-        <div
-          className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
+
+        <ResetButton
+          label="Reset points"
           onClick={() => {
             setPlayer1Points(0);
             setPlayer2Points(0);
           }}
-        >
-          ↺
-        </div>
+        />
       </div>
     </div>
   );

--- a/components/card/PlayerSetting.tsx
+++ b/components/card/PlayerSetting.tsx
@@ -1,40 +1,59 @@
+"use client";
+
+/**
+ * プレイヤー設定カード
+ *
+ * 名前・色の編集、追加・削除が可能です。
+ * 変更はローカルストレージへ自動保存されます。
+ */
+
 import { useEffect } from "react";
-import { Player } from "../../utils/types";
-import { initialPlayers } from "../../utils/cardDefinitions";
-import { setLocalStorage } from "../../utils/localFuncs";
+import type { Player } from "@/utils/types";
+import { initialPlayers } from "@/utils/cardDefinitions";
+import { setLocalStorage } from "@/utils/localFuncs";
+import ResetButton from "@/components/card/module/ResetButton";
+
+type PlayerSettingProps = {
+  players?: Player[];
+  setPlayers?: (players: Player[]) => void;
+};
 
 export default function PlayerSetting({
-  players,
+  players = [],
   setPlayers,
-}: {
-  players: Player[];
-  setPlayers: (arg: Player[]) => void;
-}) {
+}: PlayerSettingProps) {
+  const updatePlayers = (next: Player[]) => {
+    setPlayers?.(next);
+  };
+
   const handleNameChange = (index: number, newName: string) => {
-    const newPlayers = [...players];
-    newPlayers[index].name = newName;
-    setPlayers(newPlayers);
+    updatePlayers(
+      players.map((player, i) =>
+        i === index ? { ...player, name: newName } : player
+      )
+    );
   };
 
   const handleColorChange = (index: number, newColor: string) => {
-    const newPlayers = [...players];
-    newPlayers[index].color = newColor;
-    setPlayers(newPlayers);
+    updatePlayers(
+      players.map((player, i) =>
+        i === index ? { ...player, color: newColor } : player
+      )
+    );
   };
 
   const addPlayer = () => {
-    // ランダムな色を生成し、新しいプレイヤーを追加
-    const randomColor = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
-    const newPlayers = [
+    const randomColor = `#${Math.floor(Math.random() * 0xffffff)
+      .toString(16)
+      .padStart(6, "0")}`;
+    updatePlayers([
       ...players,
       { name: `Player ${players.length + 1}`, color: randomColor },
-    ];
-    setPlayers(newPlayers);
+    ]);
   };
 
   const removePlayer = (index: number) => {
-    const newPlayers = players.filter((_, i) => i !== index);
-    setPlayers(newPlayers);
+    updatePlayers(players.filter((_, i) => i !== index));
   };
 
   useEffect(() => {
@@ -46,8 +65,9 @@ export default function PlayerSetting({
     <>
       <div className="p-6 h-full overflow-y-auto max-h-[400px] [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-white/25 [&::-webkit-scrollbar-thumb]:rounded-full">
         {players.map((player, index) => (
-          <div key={index} className="flex items-center align-middle gap-1">
+          <div key={index} className="flex items-center gap-1">
             <button
+              type="button"
               className="block px-2 pb-1 rounded duration-200 hover:bg-red-500"
               onClick={() => removePlayer(index)}
             >
@@ -68,21 +88,20 @@ export default function PlayerSetting({
           </div>
         ))}
         <button
+          type="button"
           className="mt-1 w-full px-2 duration-200 hover:opacity-70"
           onClick={addPlayer}
         >
           ＋
         </button>
       </div>
-      <div
-        className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
+      <ResetButton
+        label="Reset players"
         onClick={() => {
-          setPlayers(initialPlayers);
+          updatePlayers(initialPlayers);
           setLocalStorage("players", JSON.stringify(initialPlayers));
         }}
-      >
-        ↺
-      </div>
+      />
     </>
   );
 }

--- a/components/card/Roulette.tsx
+++ b/components/card/Roulette.tsx
@@ -1,28 +1,31 @@
 "use client";
 
+/**
+ * 3D ルーレットカード
+ *
+ * プレイヤー設定の色・名前で扇形を分割し、タップで回転します。
+ * 停止後に中央ハブの色と上部ラベルで当選プレイヤーを表示します。
+ */
+
 import { Canvas, useFrame } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import { useState, useRef, useCallback } from "react";
 import { Group } from "three";
 import type { ThreeEvent } from "@react-three/fiber";
+import type { Player } from "@/utils/types";
 
-type user = {
-  name: string;
-  color: string;
-};
+/** スピン開始時の角速度 */
+const INITIAL_ANGULAR_VELOCITY = (Math.PI * 2 * 50) / 100;
 
-const initialAngularVelocity = (Math.PI * 2 * 50) / 100;
-
-function RouletteModel(props: { users: Array<user> }) {
-  const { users } = props;
-
+function RouletteModel({ players }: { players: Player[] }) {
   return (
     <group>
-      {users.map((user, i) => {
+      {players.map((player, i) => {
         const rad =
-          (Math.PI * 2 * i) / users.length + Math.PI * (1 + 2 / users.length);
+          (Math.PI * 2 * i) / players.length +
+          Math.PI * (1 + 2 / players.length);
         return (
-          <mesh key={i} position={[0, 0, 0]}>
+          <mesh key={`${player.name}-${i}`} position={[0, 0, 0]}>
             <cylinderGeometry
               args={[
                 10,
@@ -32,11 +35,11 @@ function RouletteModel(props: { users: Array<user> }) {
                 1,
                 false,
                 -rad,
-                (Math.PI * 2) / users.length,
+                (Math.PI * 2) / players.length,
               ]}
             />
             <meshStandardMaterial
-              color={user.color}
+              color={player.color}
               roughness={0.1}
               metalness={0.2}
             />
@@ -47,18 +50,21 @@ function RouletteModel(props: { users: Array<user> }) {
   );
 }
 
-function GroupComponent(props: {
-  users: Array<user>;
+function RouletteGroup({
+  players,
+  rouletteNum,
+  setRouletteNum,
+}: {
+  players: Player[];
   rouletteNum: number;
   setRouletteNum: (num: number) => void;
 }) {
-  const { users, rouletteNum, setRouletteNum } = props;
   const groupRef = useRef<Group>(null);
   const [isSpinning, setIsSpinning] = useState(false);
   const isSpinningRef = useRef(false);
   const isSpinningLastRef = useRef(true);
-  const angularVelocityRef = useRef(initialAngularVelocity);
-  const rotationYRef = useRef(1 * Math.PI);
+  const angularVelocityRef = useRef(INITIAL_ANGULAR_VELOCITY);
+  const rotationYRef = useRef(Math.PI);
 
   useFrame(() => {
     const group = groupRef.current;
@@ -68,6 +74,7 @@ function GroupComponent(props: {
       if (angularVelocityRef.current !== 0) {
         const prev = angularVelocityRef.current;
         if (prev > 0) {
+          // 徐々に減速して自然に止まる
           angularVelocityRef.current =
             prev - prev * 0.015 - (Math.PI * 2 * 0.001) / 100;
         } else {
@@ -81,11 +88,11 @@ function GroupComponent(props: {
         isSpinningLastRef.current = true;
       }
     } else if (!isSpinningRef.current && isSpinningLastRef.current) {
-      angularVelocityRef.current = initialAngularVelocity;
+      angularVelocityRef.current = INITIAL_ANGULAR_VELOCITY;
       setRouletteNum(
         Math.round(
           (((rotationYRef.current + Math.PI) % (Math.PI * 2)) / (Math.PI * 2)) *
-            (users.length - 1)
+            (players.length - 1)
         )
       );
       isSpinningLastRef.current = false;
@@ -105,6 +112,8 @@ function GroupComponent(props: {
     }
   }, []);
 
+  const hubColor = isSpinning ? 0xffffff : players[rouletteNum]?.color;
+
   return (
     <group
       ref={groupRef}
@@ -114,7 +123,7 @@ function GroupComponent(props: {
       <mesh position={[0, 1.25, 0]}>
         <cylinderGeometry args={[5, 5, 0.5, 24]} />
         <meshStandardMaterial
-          color={isSpinning ? 0xffffff : users[rouletteNum].color}
+          color={hubColor}
           roughness={0.4}
           metalness={0.1}
         />
@@ -125,25 +134,29 @@ function GroupComponent(props: {
         <meshStandardMaterial color={0xffffff} roughness={0.4} metalness={0.1} />
       </mesh>
 
-      <RouletteModel users={users} />
+      <RouletteModel players={players} />
     </group>
   );
 }
 
-export default function Roulette(props: {
-  zoomRatio: number;
-  players: Array<user>;
+export default function Roulette({
+  zoomRatio = 1,
+  players = [],
+  isActive = true,
+}: {
+  zoomRatio?: number;
+  players?: Player[];
   isActive?: boolean;
 }) {
-  const { zoomRatio, players, isActive = true } = props;
   const [rouletteNum, setRouletteNum] = useState(0);
+  const safeIndex = Math.min(rouletteNum, Math.max(players.length - 1, 0));
 
   return (
     <>
       <div className="absolute z-10 block top-3 right-1/2 translate-x-1/2 px-2 w-2/3 text-center text-2xl bg-opacity-80">
-        {players[rouletteNum].name}
+        {players[safeIndex]?.name ?? ""}
       </div>
-      {isActive ? (
+      {isActive && players.length > 0 ? (
         <Canvas
           className="h-full w-full"
           camera={{ fov: 80, position: [10, 3, 0] }}
@@ -151,9 +164,9 @@ export default function Roulette(props: {
           dpr={[1, 1.5]}
           gl={{ antialias: false, powerPreference: "low-power" }}
         >
-          <GroupComponent
-            users={players}
-            rouletteNum={rouletteNum}
+          <RouletteGroup
+            players={players}
+            rouletteNum={safeIndex}
             setRouletteNum={setRouletteNum}
           />
           <OrbitControls

--- a/components/card/Score.tsx
+++ b/components/card/Score.tsx
@@ -1,83 +1,69 @@
 "use client";
 
-import { useState, useRef } from "react";
+/**
+ * スコアカウンター
+ *
+ * 大きな数値入力と、±1 / ±100 / ±1000 / ±10000 の長押し加減算に対応します。
+ */
 
-const scoreMax = 99999;
-const scoreMin = -99999;
+import { useState } from "react";
+import { clamp } from "@/utils/clamp";
+import { useHoldRepeat } from "@/hooks/useHoldRepeat";
+import ResetButton from "@/components/card/module/ResetButton";
 
-function ajustScoreValue(value: number): number {
-  if (value > scoreMax) {
-    return scoreMax;
-  } else if (value < scoreMin) {
-    return scoreMin;
-  }
-  return value;
-}
+const SCORE_MAX = 99999;
+const SCORE_MIN = -99999;
+
+const SCORE_ADJUSTMENTS = [
+  { label: "<", value: -1, className: "mt-[-8px] text-3xl" },
+  { label: ">", value: 1, className: "mt-[-8px] text-3xl" },
+  { label: "-100", value: -100 },
+  { label: "+100", value: 100 },
+  { label: "-1000", value: -1000 },
+  { label: "+1000", value: 1000 },
+  { label: "-10000", value: -10000 },
+  { label: "+10000", value: 10000 },
+] as const;
 
 export default function Score() {
   const [count, setCount] = useState(0);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const { onHoldStart, onHoldEnd } = useHoldRepeat();
 
-  const scoreAdjustments = [
-    { label: "<", value: -1, className: "mt-[-8px] text-3xl" },
-    { label: ">", value: 1, className: "mt-[-8px] text-3xl" },
-    { label: "-100", value: -100 },
-    { label: "+100", value: 100 },
-    { label: "-1000", value: -1000 },
-    { label: "+1000", value: 1000 },
-    { label: "-10000", value: -10000 },
-    { label: "+10000", value: 10000 },
-  ];
-
-  const handleMouseDown = (adjustment: number) => {
-    setCount((prevCount) => ajustScoreValue(prevCount + adjustment));
-    intervalRef.current = setInterval(() => {
-      setCount((prevCount) => ajustScoreValue(prevCount + adjustment));
-    }, 100);
-  };
-
-  const handleMouseUp = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
+  const adjust = (delta: number) => {
+    setCount((prev) => clamp(prev + delta, SCORE_MIN, SCORE_MAX));
   };
 
   return (
-    <>
-      <div className="p-6">
-        <p className="text-[8px] opacity-50">INPUT / ARROW KEY / SCROLL</p>
-        <input
-          className="inline-block w-44 bg-transparent text-5xl text-center font-bold outline-none"
-          type="number"
-          onChange={(e) => setCount(ajustScoreValue(parseInt(e.target.value)))}
-          value={count}
-        />
-        <div>
-          <div className="grid grid-cols-2 gap-0 text-base">
-            {scoreAdjustments.map((adjustment, index) => (
-              <div key={index}>
-                <button
-                  className={`px-2 duration-200 hover:opacity-70 ${
-                    adjustment.className || ""
-                  }`}
-                  onMouseDown={() => handleMouseDown(adjustment.value)}
-                  onMouseUp={handleMouseUp}
-                  onMouseLeave={handleMouseUp}
-                >
-                  {adjustment.label}
-                </button>
-              </div>
-            ))}
+    <div className="p-6">
+      <p className="text-[8px] opacity-50">INPUT / ARROW KEY / SCROLL</p>
+      <input
+        className="inline-block w-44 bg-transparent text-5xl text-center font-bold outline-none"
+        type="number"
+        value={count}
+        onChange={(e) =>
+          setCount(
+            clamp(Number.parseInt(e.target.value, 10) || 0, SCORE_MIN, SCORE_MAX)
+          )
+        }
+      />
+      <div className="grid grid-cols-2 gap-0 text-base">
+        {SCORE_ADJUSTMENTS.map((adjustment) => (
+          <div key={adjustment.label}>
+            <button
+              type="button"
+              className={`px-2 duration-200 hover:opacity-70 ${
+                "className" in adjustment ? adjustment.className : ""
+              }`}
+              onMouseDown={() => onHoldStart(() => adjust(adjustment.value))}
+              onMouseUp={onHoldEnd}
+              onMouseLeave={onHoldEnd}
+            >
+              {adjustment.label}
+            </button>
           </div>
-        </div>
-        <div
-          className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
-          onClick={() => setCount(0)}
-        >
-          ↺
-        </div>
+        ))}
       </div>
-    </>
+      <ResetButton label="Reset score" onClick={() => setCount(0)} />
+    </div>
   );
 }

--- a/components/card/StyleSetting.tsx
+++ b/components/card/StyleSetting.tsx
@@ -1,78 +1,96 @@
-'use Client';
+"use client";
 
-import { CardStyle } from "../../utils/types";
-import { initialStyle, fonts } from "../../utils/cardDefinitions";
-import { setLocalStorage } from "../../utils/localFuncs";
+/**
+ * スタイル設定カード
+ *
+ * 交互に使う背景色・文字色と、フォントスタイル番号を変更できます。
+ */
 
-const colorFields = [
+import type { CardStyle } from "@/utils/types";
+import { initialStyle, fonts } from "@/utils/cardDefinitions";
+import { setLocalStorage } from "@/utils/localFuncs";
+import ResetButton from "@/components/card/module/ResetButton";
+
+const COLOR_FIELDS: { label: string; key: keyof CardStyle }[] = [
   { label: "Base 1", key: "bgColor_1" },
   { label: "Font 1", key: "fontColor_1" },
   { label: "Base 2", key: "bgColor_2" },
   { label: "Font 2", key: "fontColor_2" },
 ];
 
+type StyleSettingProps = {
+  cardStyle?: CardStyle;
+  setCardStyle?: (style: CardStyle) => void;
+};
+
 export default function StyleSetting({
-  cardStyle,
+  cardStyle = initialStyle,
   setCardStyle,
-}: {
-  cardStyle: CardStyle;
-  setCardStyle: (cardStyle: CardStyle) => void;
-}) {
+}: StyleSettingProps) {
+  const updateStyle = (partial: Partial<CardStyle>) => {
+    setCardStyle?.({ ...cardStyle, ...partial });
+  };
+
   return (
-    <div className={"relative w-56 h-56 text-center"}>
+    <div className="relative w-56 h-56 text-center">
       <div className="py-6 flex flex-col justify-center items-center gap-2">
-        {colorFields.map((field) => (
-          <div key={field.key} className="px-8 grid grid-cols-2 gap-x-2 justify-center items-center">
+        {COLOR_FIELDS.map((field) => (
+          <div
+            key={field.key}
+            className="px-8 grid grid-cols-2 gap-x-2 justify-center items-center"
+          >
             <div className="block text-left">{field.label}: </div>
             <input
               className="block w-6 m-auto bg-transparent cursor-pointer"
               type="color"
-              value={cardStyle[field.key as keyof CardStyle]}
-              onChange={(e) =>
-                setCardStyle({ ...cardStyle, [field.key]: e.target.value })
-              }
+              value={String(cardStyle[field.key])}
+              onChange={(e) => updateStyle({ [field.key]: e.target.value })}
             />
           </div>
         ))}
-        <div
-          className="flex justify-center items-center text-xl"
-        >
-          <div
-            onClick={() => {
-              setCardStyle({
-                ...cardStyle,
-                fontStyle: cardStyle.fontStyle - 1 < 1 ? fonts.length : cardStyle.fontStyle - 1,
-              });
-            }}
+
+        <div className="flex justify-center items-center text-xl">
+          <button
+            type="button"
             className="w-4 cursor-pointer duration-200 opacity-30 hover:opacity-100"
+            onClick={() =>
+              updateStyle({
+                fontStyle:
+                  cardStyle.fontStyle - 1 < 1
+                    ? fonts.length
+                    : cardStyle.fontStyle - 1,
+              })
+            }
           >
             {"<"}
-          </div>
+          </button>
           <div className="text-center w-32">
             Font Style {cardStyle.fontStyle}
           </div>
-          <div
-            onClick={() => {
-              setCardStyle({
-                ...cardStyle,
-                fontStyle: cardStyle.fontStyle + 1 > fonts.length ? 1 : cardStyle.fontStyle + 1,
-              });
-            }}
+          <button
+            type="button"
             className="w-4 cursor-pointer duration-200 opacity-30 hover:opacity-100"
+            onClick={() =>
+              updateStyle({
+                fontStyle:
+                  cardStyle.fontStyle + 1 > fonts.length
+                    ? 1
+                    : cardStyle.fontStyle + 1,
+              })
+            }
           >
             {">"}
-          </div>
+          </button>
         </div>
       </div>
-      <div
-        className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
+
+      <ResetButton
+        label="Reset style"
         onClick={() => {
-          setCardStyle(initialStyle);
+          setCardStyle?.(initialStyle);
           setLocalStorage("cardStyle", JSON.stringify(initialStyle));
         }}
-      >
-        ↺
-      </div>
+      />
     </div>
   );
 }

--- a/components/card/Timer.tsx
+++ b/components/card/Timer.tsx
@@ -1,166 +1,158 @@
 "use client";
 
+/**
+ * タイマーカード
+ *
+ * カウントダウン・長押しでの加減算・デフォルト時間の保存に対応します。
+ * 時間切れ時はシェイクアニメーションで知らせます。
+ */
+
 import { useState, useEffect, useRef } from "react";
+import { clamp } from "@/utils/clamp";
+import { useHoldRepeat } from "@/hooks/useHoldRepeat";
 
-const timerMax = 359999; // 99:59:59 (最大値)
-const timerMin = 0; // 00:00:00 (最小値)
+const TIMER_MAX = 359999; // 99:59:59
+const TIMER_MIN = 0;
 
-function adjustTimerValue(value: number): number {
-  if (value > timerMax) {
-    return timerMax;
-  } else if (value < timerMin) {
-    return timerMin;
-  }
-  return value;
+const TIME_ADJUSTMENTS = [
+  { label: "-10s", value: -10 },
+  { label: "-1s", value: -1 },
+  { label: "+1s", value: 1 },
+  { label: "+10s", value: 10 },
+  { label: "-10m", value: -600 },
+  { label: "-1m", value: -60 },
+  { label: "+1m", value: 60 },
+  { label: "+10m", value: 600 },
+  { label: "-10h", value: -36000 },
+  { label: "-1h", value: -3600 },
+  { label: "+1h", value: 3600 },
+  { label: "+10h", value: 36000 },
+] as const;
+
+function formatTime(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return [
+    String(hours).padStart(2, "0"),
+    String(minutes).padStart(2, "0"),
+    String(seconds).padStart(2, "0"),
+  ].join(":");
 }
 
 export default function Timer() {
   const [defaultTime, setDefaultTime] = useState(0);
-  const [time, setTime] = useState(defaultTime);
+  const [time, setTime] = useState(0);
   const [isRunning, setIsRunning] = useState(false);
   const [isTimeUp, setIsTimeUp] = useState(false);
   const [saveDefaultText, setSaveDefaultText] = useState("SAVE AS DEFAULT");
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const { onHoldStart, onHoldEnd } = useHoldRepeat();
 
+  // カウントダウン用 interval
   useEffect(() => {
     if (isRunning) {
-      intervalRef.current = setInterval(() => {
-        setTime((prevTime) => {
-          const nextTime = adjustTimerValue(prevTime - 1);
-          if (nextTime === timerMin) {
+      tickRef.current = setInterval(() => {
+        setTime((prev) => {
+          const next = clamp(prev - 1, TIMER_MIN, TIMER_MAX);
+          if (next === TIMER_MIN) {
             setIsRunning(false);
             setIsTimeUp(true);
           }
-          return nextTime;
+          return next;
         });
       }, 1000);
-    } else if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
     }
+
     return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
+      if (tickRef.current) {
+        clearInterval(tickRef.current);
+        tickRef.current = null;
       }
     };
   }, [isRunning]);
 
-  const formatTime = (time: number) => {
-    const hours = Math.floor(time / 3600);
-    const minutes = Math.floor((time % 3600) / 60);
-    const seconds = time % 60;
-    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(
-      2,
-      "0"
-    )}:${String(seconds).padStart(2, "0")}`;
-  };
-
-  const timeAdjustments = [
-    { label: "-10s", value: -10 },
-    { label: "-1s", value: -1 },
-    { label: "+1s", value: 1 },
-    { label: "+10s", value: 10 },
-    { label: "-10m", value: -600 },
-    { label: "-1m", value: -60 },
-    { label: "+1m", value: 60 },
-    { label: "+10m", value: 600 },
-    { label: "-10h", value: -36000 },
-    { label: "-1h", value: -3600 },
-    { label: "+1h", value: 3600 },
-    { label: "+10h", value: 36000 },
-  ];
-
-  const handleMouseDown = (adjustment: number) => {
-    setTime((prevTime) => adjustTimerValue(prevTime + adjustment));
-    intervalRef.current = setInterval(() => {
-      setTime((prevTime) => adjustTimerValue(prevTime + adjustment));
-    }, 100);
-  };
-
-  const handleMouseUp = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
-  };
+  const locked = isTimeUp || isRunning;
 
   return (
-    <>
-      <div className={"p-4 text-center" + (isTimeUp ? " shake-animation" : "")}>
-        <div
-          className={
-            "inline-block w-44 bg-transparent text-4xl font-bold text-center outline-none" +
-            (isTimeUp ? " animate-pulse" : "")
-          }
-        >
-          {formatTime(time)}
-        </div>
-        <div className="flex justify-center align-middle text-base">
-          <div
-            className={
-              "px-5 py-2 text-lg" +
-              (isTimeUp
-                ? " opacity-70"
-                : " cursor-pointer duration-200 hover:opacity-70")
-            }
-            onClick={() => {
-              if (!isTimeUp) {
-                setIsRunning(!isRunning);
-              }
-            }}
-          >
-            {isRunning ? "STOP" : "START"}
-          </div>
-          <div
-            className={
-              "px-5 py-2 text-lg duration-200 hover:opacity-70" +
-              (isRunning ? " opacity-70" : " cursor-pointer")
-            }
-            onClick={() => {
-              if (isRunning) return;
-              setTime(defaultTime);
-              setIsTimeUp(false);
-            }}
-          >
-            RESET
-          </div>
-        </div>
-        <div className="grid grid-cols-4 grid-rows-3 justify-center align-middle text-base">
-          {timeAdjustments.map((adjustment, index) => (
-            <div key={index} className="flex place-content-between text-base">
-              <button
-                className={
-                  "px-1 py-0.5 duration-200" +
-                  (isTimeUp || isRunning
-                    ? " opacity-70"
-                    : " hover:opacity-70")
-                }
-                onMouseDown={() => handleMouseDown(adjustment.value)}
-                onMouseUp={handleMouseUp}
-                onMouseLeave={handleMouseUp}
-              >
-                {adjustment.label}
-              </button>
-            </div>
-          ))}
-        </div>
-        <div
-          className={
-            "mt-2 text-xs cursor-pointer duration-200 hover:opacity-70" +
-            (isTimeUp || isRunning ? " opacity-70" : "")
-          }
+    <div className={`p-4 text-center${isTimeUp ? " shake-animation" : ""}`}>
+      <div
+        className={`inline-block w-44 bg-transparent text-4xl font-bold text-center outline-none${
+          isTimeUp ? " animate-pulse" : ""
+        }`}
+      >
+        {formatTime(time)}
+      </div>
+
+      <div className="flex justify-center items-center text-base">
+        <button
+          type="button"
+          className={`px-5 py-2 text-lg${
+            isTimeUp
+              ? " opacity-70"
+              : " cursor-pointer duration-200 hover:opacity-70"
+          }`}
           onClick={() => {
-            if (isTimeUp || isRunning) return;
-            setDefaultTime(time);
-            setSaveDefaultText("SAVED");
-            setTimeout(() => {
-              setSaveDefaultText("SAVE AS DEFAULT");
-            }, 2000);
+            if (!isTimeUp) setIsRunning((prev) => !prev);
           }}
         >
-          {saveDefaultText}
-        </div>
+          {isRunning ? "STOP" : "START"}
+        </button>
+        <button
+          type="button"
+          className={`px-5 py-2 text-lg duration-200 hover:opacity-70${
+            isRunning ? " opacity-70" : " cursor-pointer"
+          }`}
+          onClick={() => {
+            if (isRunning) return;
+            setTime(defaultTime);
+            setIsTimeUp(false);
+          }}
+        >
+          RESET
+        </button>
       </div>
-    </>
+
+      <div className="grid grid-cols-4 grid-rows-3 justify-center items-center text-base">
+        {TIME_ADJUSTMENTS.map((adjustment) => (
+          <div key={adjustment.label} className="flex place-content-between">
+            <button
+              type="button"
+              className={`px-1 py-0.5 duration-200${
+                locked ? " opacity-70" : " hover:opacity-70"
+              }`}
+              disabled={locked}
+              onMouseDown={() => {
+                if (locked) return;
+                onHoldStart(() =>
+                  setTime((prev) =>
+                    clamp(prev + adjustment.value, TIMER_MIN, TIMER_MAX)
+                  )
+                );
+              }}
+              onMouseUp={onHoldEnd}
+              onMouseLeave={onHoldEnd}
+            >
+              {adjustment.label}
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        className={`mt-2 text-xs cursor-pointer duration-200 hover:opacity-70${
+          locked ? " opacity-70" : ""
+        }`}
+        onClick={() => {
+          if (locked) return;
+          setDefaultTime(time);
+          setSaveDefaultText("SAVED");
+          setTimeout(() => setSaveDefaultText("SAVE AS DEFAULT"), 2000);
+        }}
+      >
+        {saveDefaultText}
+      </button>
+    </div>
   );
 }

--- a/components/card/Token.tsx
+++ b/components/card/Token.tsx
@@ -1,103 +1,89 @@
 "use client";
 
-import { useState, useRef } from "react";
+/**
+ * トークン（リソース）カウンター
+ *
+ * 4 種類のアイコンごとに個数を加減算できます。
+ * 入力欄・長押しボタンに対応します。
+ */
 
-const tokenMax = 99;
-const tokenMin = -99;
+import { useState } from "react";
+import { clamp } from "@/utils/clamp";
+import { useHoldRepeat } from "@/hooks/useHoldRepeat";
+import ResetButton from "@/components/card/module/ResetButton";
 
-function ajustTokenValue(value: number): number {
-  if (value > tokenMax) {
-    return tokenMax;
-  } else if (value < tokenMin) {
-    return tokenMin;
-  }
-  return value;
-}
+const TOKEN_MAX = 99;
+const TOKEN_MIN = -99;
+const TOKEN_ICONS = ["🩷", "🪙", "☘️", "🧊️"] as const;
+const INITIAL_COUNTS = [0, 0, 0, 0];
 
 export default function Token() {
-  const [tokenCounts, setTokenCounts] = useState([0, 0, 0, 0]);
-  const tokenIcons = ["🩷", "🪙", "☘️", "🧊️"];
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [tokenCounts, setTokenCounts] = useState([...INITIAL_COUNTS]);
+  const { onHoldStart, onHoldEnd } = useHoldRepeat();
 
-  const handleTokenChange = (index: number, adjustment: number) => {
-    setTokenCounts((prevCounts) => {
-      const newCounts = [...prevCounts];
-      newCounts[index] = ajustTokenValue(newCounts[index] + adjustment);
-      return newCounts;
+  /** 指定インデックスの値を絶対値で更新 */
+  const setAt = (index: number, value: number) => {
+    setTokenCounts((prev) => {
+      const next = [...prev];
+      next[index] = clamp(value, TOKEN_MIN, TOKEN_MAX);
+      return next;
     });
   };
 
-  const handleInputChange = (index: number, value: number) => {
-    setTokenCounts((prevCounts) => {
-      const newCounts = [...prevCounts];
-      newCounts[index] = ajustTokenValue(value);
-      return newCounts;
+  /** 指定インデックスの値を相対値で更新（長押し用・最新 state を参照） */
+  const adjustAt = (index: number, delta: number) => {
+    setTokenCounts((prev) => {
+      const next = [...prev];
+      next[index] = clamp(prev[index] + delta, TOKEN_MIN, TOKEN_MAX);
+      return next;
     });
-  };
-
-  const handleMouseDown = (index: number, adjustment: number) => {
-    handleTokenChange(index, adjustment);
-    intervalRef.current = setInterval(() => {
-      handleTokenChange(index, adjustment);
-    }, 100);
-  };
-
-  const handleMouseUp = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-    }
   };
 
   return (
-    <>
-      <div className="h-full flex flex-col justify-center items-center gap-2 p-4 text-2xl">
-        <p className="my-[-10px] text-[9px] opacity-50">
-          INPUT / ARROW KEY / SCROLL
-        </p>
-        {tokenCounts.map((count, index) => (
-          <div key={index} className="flex justify-center items-center">
-            <button
-              className="px-4 text-center transition hover:opacity-70 hover:-translate-x-2"
-              onMouseDown={() => handleMouseDown(index, -1)}
-              onMouseUp={handleMouseUp}
-              onMouseLeave={handleMouseUp}
-            >
-              {"<"}
-            </button>
-            <div
-              className={"text-3xl h-8 leading-8"}
-              style={{
-                transform: "scale(" + (100 + count) / 100 + ")",
-              }}
-            >
-              {tokenIcons[index]}
-            </div>
-            <input
-              className="inline-block ml-3 w-12 bg-transparent outline-none text-center"
-              type="number"
-              onChange={(e) =>
-                handleInputChange(index, parseInt(e.target.value))
-              }
-              value={count}
-            />
-            <button
-              className="px-4 text-center transition hover:opacity-70 hover:translate-x-2"
-              onMouseDown={() => handleMouseDown(index, 1)}
-              onMouseUp={handleMouseUp}
-              onMouseLeave={handleMouseUp}
-            >
-              {">"}
-            </button>
+    <div className="h-full flex flex-col justify-center items-center gap-2 p-4 text-2xl">
+      <p className="my-[-10px] text-[9px] opacity-50">
+        INPUT / ARROW KEY / SCROLL
+      </p>
+      {tokenCounts.map((count, index) => (
+        <div key={TOKEN_ICONS[index]} className="flex justify-center items-center">
+          <button
+            type="button"
+            className="px-4 text-center transition hover:opacity-70 hover:-translate-x-2"
+            onMouseDown={() => onHoldStart(() => adjustAt(index, -1))}
+            onMouseUp={onHoldEnd}
+            onMouseLeave={onHoldEnd}
+          >
+            {"<"}
+          </button>
+          <div
+            className="text-3xl h-8 leading-8"
+            style={{ transform: `scale(${(100 + count) / 100})` }}
+          >
+            {TOKEN_ICONS[index]}
           </div>
-        ))}
-        <div
-          className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
-          onClick={() => setTokenCounts([0, 0, 0, 0])}
-        >
-          ↺
+          <input
+            className="inline-block ml-3 w-12 bg-transparent outline-none text-center"
+            type="number"
+            value={count}
+            onChange={(e) =>
+              setAt(index, Number.parseInt(e.target.value, 10) || 0)
+            }
+          />
+          <button
+            type="button"
+            className="px-4 text-center transition hover:opacity-70 hover:translate-x-2"
+            onMouseDown={() => onHoldStart(() => adjustAt(index, 1))}
+            onMouseUp={onHoldEnd}
+            onMouseLeave={onHoldEnd}
+          >
+            {">"}
+          </button>
         </div>
-      </div>
-    </>
+      ))}
+      <ResetButton
+        label="Reset tokens"
+        onClick={() => setTokenCounts([...INITIAL_COUNTS])}
+      />
+    </div>
   );
 }

--- a/components/card/Turn.tsx
+++ b/components/card/Turn.tsx
@@ -1,29 +1,34 @@
 "use client";
 
+/**
+ * ターンカウンター
+ *
+ * 表示をタップすると「総ターン数」と「現在のプレイヤー」を切り替えます。
+ */
+
 import { useState } from "react";
-import { Player } from "../../utils/types";
+import type { Player } from "@/utils/types";
+import ResetButton from "@/components/card/module/ResetButton";
 
-export default function TurnCounter(props: { players: Player[] }) {
-  const { players } = props;
-
+export default function Turn({ players = [] }: { players?: Player[] }) {
   const [turnCount, setTurnCount] = useState(0);
   const [turnPlayerIndex, setTurnPlayerIndex] = useState(0);
   const [isTurnCountMode, setIsTurnCountMode] = useState(true);
 
   const handleNext = () => {
     if (isTurnCountMode) {
-      setTurnCount(turnCount + 1);
-    } else {
-      setTurnPlayerIndex((turnPlayerIndex + 1) % players.length);
+      setTurnCount((prev) => prev + 1);
+    } else if (players.length > 0) {
+      setTurnPlayerIndex((prev) => (prev + 1) % players.length);
     }
   };
 
   const handlePrevious = () => {
     if (isTurnCountMode) {
-      setTurnCount((prevCount) => Math.max(prevCount - 1, 0));
-    } else {
+      setTurnCount((prev) => Math.max(prev - 1, 0));
+    } else if (players.length > 0) {
       setTurnPlayerIndex(
-        (turnPlayerIndex - 1 + players.length) % players.length
+        (prev) => (prev - 1 + players.length) % players.length
       );
     }
   };
@@ -39,38 +44,36 @@ export default function TurnCounter(props: { players: Player[] }) {
   return (
     <div className="h-full flex flex-col justify-center items-center p-4">
       <p className="text-2xl">Turn</p>
-      <p
+      <button
+        type="button"
         className={
           isTurnCountMode
             ? "text-6xl mt-4 leading-none cursor-pointer"
             : "text-4xl mt-4 leading-none cursor-pointer"
         }
-        onClick={() => setIsTurnCountMode(
-          (prevMode) => !prevMode
-        )}
+        onClick={() => setIsTurnCountMode((prev) => !prev)}
       >
-        {isTurnCountMode ? turnCount : players[turnPlayerIndex].name}
-      </p>
+        {isTurnCountMode
+          ? turnCount
+          : (players[turnPlayerIndex]?.name ?? "-")}
+      </button>
       <div className="mt-4 flex justify-center items-center">
         <button
+          type="button"
           className="px-8 text-4xl leading-none cursor-pointer duration-200 hover:opacity-70"
           onClick={handlePrevious}
         >
           {"<"}
         </button>
         <button
+          type="button"
           className="px-8 text-4xl leading-none cursor-pointer duration-200 hover:opacity-70"
           onClick={handleNext}
         >
           {">"}
         </button>
       </div>
-      <div
-        className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
-        onClick={handleReset}
-      >
-        ↺
-      </div>
+      <ResetButton label="Reset turn" onClick={handleReset} />
     </div>
   );
 }

--- a/components/card/Winner.tsx
+++ b/components/card/Winner.tsx
@@ -7,7 +7,7 @@
  * 表示は 4 個まではトロフィー連打、それ以上は「🏆 × N」形式です。
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { Player } from "@/utils/types";
 import { clamp } from "@/utils/clamp";
 import ResetButton from "@/components/card/module/ResetButton";
@@ -25,11 +25,15 @@ function formatWins(count: number): string {
 
 export default function Winner({ players = [] }: { players?: Player[] }) {
   const [playerWins, setPlayerWins] = useState(() => players.map(() => 0));
+  const prevLengthRef = useRef(players.length);
 
-  // プレイヤー人数が変わったら勝利数をリセット
+  // プレイヤー人数が変わったときだけ勝利数をリセット（名前変更などでは維持）
   useEffect(() => {
-    setPlayerWins(players.map(() => 0));
-  }, [players.length]);
+    if (prevLengthRef.current !== players.length) {
+      prevLengthRef.current = players.length;
+      setPlayerWins(players.map(() => 0));
+    }
+  }, [players]);
 
   const handleWinChange = (index: number, delta: number) => {
     setPlayerWins((prev) => {

--- a/components/card/Winner.tsx
+++ b/components/card/Winner.tsx
@@ -44,22 +44,26 @@ export default function Winner({ players = [] }: { players?: Player[] }) {
   };
 
   return (
-    <div className="p-6 h-full flex flex-col items-center gap-1 overflow-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-white/25 [&::-webkit-scrollbar-thumb]:rounded-full">
+    <div className="relative p-6 h-full flex flex-col justify-center items-center gap-1 overflow-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-white/25 [&::-webkit-scrollbar-thumb]:rounded-full">
       {players.map((player, index) => (
         <div
           key={`${player.name}-${index}`}
           className="w-full grid grid-cols-2 place-content-between"
         >
+          {/*
+            button のデフォルトスタイル（shrink / padding）だと
+            グリッドセルを満たせず左上に寄るため、幅と見た目を div 相当に揃える
+          */}
           <button
             type="button"
-            className="cursor-pointer text-left"
+            className="w-full cursor-pointer bg-transparent border-0 p-0 m-0 text-inherit font-inherit"
             onClick={() => handleWinChange(index, 1)}
           >
             {player.name}
           </button>
           <button
             type="button"
-            className="cursor-pointer text-left"
+            className="w-full cursor-pointer bg-transparent border-0 p-0 m-0 text-inherit font-inherit"
             onClick={() => handleWinChange(index, -1)}
           >
             {formatWins(playerWins[index] ?? 0)}

--- a/components/card/Winner.tsx
+++ b/components/card/Winner.tsx
@@ -1,85 +1,71 @@
 "use client";
 
-import { useState } from "react";
-import { Player } from "../../utils/types";
+/**
+ * 勝利数カウンター
+ *
+ * プレイヤー名タップで＋1、トロフィー側タップで −1。
+ * 表示は 4 個まではトロフィー連打、それ以上は「🏆 × N」形式です。
+ */
 
-// 勝利数の最大値と最小値
-const maxWins = 99;
-const minWins = 0;
+import { useState, useEffect } from "react";
+import type { Player } from "@/utils/types";
+import { clamp } from "@/utils/clamp";
+import ResetButton from "@/components/card/module/ResetButton";
 
-// トロフィーを並べて表示できる最大
-const maxDisplayWins = 4;
+const MAX_WINS = 99;
+const MIN_WINS = 0;
+/** トロフィーを並べて表示できる上限 */
+const MAX_DISPLAY_WINS = 4;
 
-function adjustWinCount(value: number): number {
-  if (value > maxWins) {
-    return maxWins;
-  } else if (value < minWins) {
-    return minWins;
-  }
-  return value;
+function formatWins(count: number): string {
+  if (count === 0) return "🏆 × 0";
+  if (count <= MAX_DISPLAY_WINS) return "🏆".repeat(count);
+  return `🏆 × ${count}`;
 }
 
-export default function WinnerCounter({ players }: { players: Player[] }) {
-  const [playerWins, setPlayerWins] = useState(players.map(() => 0));
-  const [playerDisplayTexts, setPlayerDisplayTexts] = useState(
-    players.map(() => "🏆 × 0")
-  );
+export default function Winner({ players = [] }: { players?: Player[] }) {
+  const [playerWins, setPlayerWins] = useState(() => players.map(() => 0));
 
-  // 勝利数と勝利数表示更新する関数
-  const handleWinChange = (index: number, increment: number) => {
-    const newWins = [...playerWins];
-    const newCount = adjustWinCount(newWins[index] + increment);
-    newWins[index] = newCount;
-
-    const newDisplayTexts = [...playerDisplayTexts];
-    if (newCount == 0) {
-      newDisplayTexts[index] = "🏆 × 0";
-    } else if (newCount <= maxDisplayWins) {
-      newDisplayTexts[index] = "🏆".repeat(newCount);
-    } else {
-      newDisplayTexts[index] = "🏆 × " + newCount;
-    }
-
-    setPlayerWins(newWins);
-    setPlayerDisplayTexts(newDisplayTexts);
-  };
-
-  // プレイヤー数に変更があった際はステートを更新
-  if (players.length !== playerWins.length) {
+  // プレイヤー人数が変わったら勝利数をリセット
+  useEffect(() => {
     setPlayerWins(players.map(() => 0));
-    setPlayerDisplayTexts(players.map(() => "🏆 × 0"));
-  }
+  }, [players.length]);
+
+  const handleWinChange = (index: number, delta: number) => {
+    setPlayerWins((prev) => {
+      const next = [...prev];
+      next[index] = clamp(prev[index] + delta, MIN_WINS, MAX_WINS);
+      return next;
+    });
+  };
 
   return (
     <div className="p-6 h-full flex flex-col items-center gap-1 overflow-auto [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:bg-white/25 [&::-webkit-scrollbar-thumb]:rounded-full">
       {players.map((player, index) => (
         <div
-          key={index}
+          key={`${player.name}-${index}`}
           className="w-full grid grid-cols-2 place-content-between"
         >
-          <div
-            className="cursor-pointer"
+          <button
+            type="button"
+            className="cursor-pointer text-left"
             onClick={() => handleWinChange(index, 1)}
           >
             {player.name}
-          </div>
-          <div
-            className="cursor-pointer"
+          </button>
+          <button
+            type="button"
+            className="cursor-pointer text-left"
             onClick={() => handleWinChange(index, -1)}
           >
-            {playerDisplayTexts[index]}
-          </div>
+            {formatWins(playerWins[index] ?? 0)}
+          </button>
         </div>
       ))}
-      <div
-        className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
-        onClick={() => {
-          setPlayerWins(players.map(() => 0));
-          setPlayerDisplayTexts(players.map(() => "🏆 × 0"));
-        }}
-      >
-        ↺
-      </div>
+      <ResetButton
+        label="Reset wins"
+        onClick={() => setPlayerWins(players.map(() => 0))}
+      />
     </div>
   );
 }

--- a/components/card/module/CloseButton.tsx
+++ b/components/card/module/CloseButton.tsx
@@ -1,40 +1,40 @@
-import React from "react";
-import { CardSetting } from "../../../utils/types";
+/**
+ * カードを閉じる（setter に戻す）ボタン
+ */
 
-interface CloseButtonProps {
+import type { CardSetting } from "@/utils/types";
+
+type CloseButtonProps = {
   index: number;
   cardList: CardSetting[];
   setCardList: (list: CardSetting[]) => void;
   isHidden?: boolean;
-}
+};
 
-const CloseButton: React.FC<CloseButtonProps> = ({
+export default function CloseButton({
   index,
   cardList,
   setCardList,
-  isHidden,
-}) => {
+  isHidden = false,
+}: CloseButtonProps) {
+  if (isHidden) return null;
+
   return (
-    <div
-      className={
-        "absolute z-10 top-1 right-1 px-1 cursor-pointer text-2xl leading-none duration-200 opacity-30 hover:opacity-100"
-      }
-      style={{
-        display: isHidden ? "none" : "block",
-      }}
+    <button
+      type="button"
+      aria-label="Close card"
+      className="absolute z-10 top-1 right-1 px-1 cursor-pointer text-2xl leading-none duration-200 opacity-30 hover:opacity-100"
       onClick={() => {
-        const newList = [...cardList];
-        newList[index] = {
+        const next = [...cardList];
+        next[index] = {
           component: "setter",
-          x: newList[index].x,
-          y: newList[index].y,
+          x: next[index].x,
+          y: next[index].y,
         };
-        setCardList(newList);
+        setCardList(next);
       }}
     >
       ×
-    </div>
+    </button>
   );
-};
-
-export default CloseButton;
+}

--- a/components/card/module/DragIcon.tsx
+++ b/components/card/module/DragIcon.tsx
@@ -1,16 +1,20 @@
-import React from "react";
+/**
+ * カード左上のドラッグハンドル
+ *
+ * このアイコンだけを draggable にし、カード本体の操作と干渉しないようにしています。
+ */
 
-interface DragIconProps {
+type DragIconProps = {
   index: number;
   handleDragStart: (index: number, e: React.DragEvent<HTMLDivElement>) => void;
   fontColor: string;
-}
+};
 
-const DragIcon: React.FC<DragIconProps> = ({
+export default function DragIcon({
   index,
   handleDragStart,
   fontColor,
-}) => {
+}: DragIconProps) {
   return (
     <div
       className="absolute z-10 top-0 left-0 p-1 cursor-move duration-200 opacity-30 hover:opacity-100"
@@ -23,11 +27,10 @@ const DragIcon: React.FC<DragIconProps> = ({
         viewBox="0 -960 960 960"
         width="20px"
         fill={fontColor}
+        aria-hidden
       >
         <path d="M360-160q-33 0-56.5-23.5T280-240q0-33 23.5-56.5T360-320q33 0 56.5 23.5T440-240q0 33-23.5 56.5T360-160Zm240 0q-33 0-56.5-23.5T520-240q0-33 23.5-56.5T600-320q33 0 56.5 23.5T680-240q0 33-23.5 56.5T600-160ZM360-400q-33 0-56.5-23.5T280-480q0-33 23.5-56.5T360-560q33 0 56.5 23.5T440-480q0 33-23.5 56.5T360-400Zm240 0q-33 0-56.5-23.5T520-480q0-33 23.5-56.5T600-560q33 0 56.5 23.5T680-480q0 33-23.5 56.5T600-400ZM360-640q-33 0-56.5-23.5T280-720q0-33 23.5-56.5T360-800q33 0 56.5 23.5T440-720q0 33-23.5 56.5T360-640Zm240 0q-33 0-56.5-23.5T520-720q0-33 23.5-56.5T600-800q33 0 56.5 23.5T680-720q0 33-23.5 56.5T600-640Z" />
       </svg>
     </div>
   );
-};
-
-export default DragIcon;
+}

--- a/components/card/module/ResetButton.tsx
+++ b/components/card/module/ResetButton.tsx
@@ -1,0 +1,28 @@
+/**
+ * カード左下に共通で置くリセットボタン
+ *
+ * 見た目と配置を揃えるため、各カードで同じクラスを繰り返さず
+ * このコンポーネント経由で描画します。
+ */
+
+type ResetButtonProps = {
+  onClick: () => void;
+  /** アクセシビリティ用のラベル */
+  label?: string;
+};
+
+export default function ResetButton({
+  onClick,
+  label = "Reset",
+}: ResetButtonProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className="absolute bottom-1 left-2 text-xl cursor-pointer duration-200 opacity-30 hover:opacity-100"
+      onClick={onClick}
+    >
+      ↺
+    </button>
+  );
+}

--- a/hooks/useHoldRepeat.ts
+++ b/hooks/useHoldRepeat.ts
@@ -1,0 +1,43 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * ボタン長押しで同じ操作を繰り返すためのカスタムフック
+ *
+ * Score / Token / Timer / OneOnOne などで共通していた
+ * mousedown → setInterval → mouseup/leave で clear するパターンをまとめています。
+ *
+ * @param intervalMs - 繰り返し間隔（ミリ秒）。既定は 100ms
+ * @returns onHoldStart / onHoldEnd（ボタンの onMouseDown / onMouseUp などに渡す）
+ */
+export function useHoldRepeat(intervalMs = 100) {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clear = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // アンマウント時に必ずタイマーを解放する
+  useEffect(() => clear, [clear]);
+
+  /**
+   * 長押し開始: まず 1 回実行し、以降は interval で繰り返す
+   */
+  const onHoldStart = useCallback(
+    (action: () => void) => {
+      clear();
+      action();
+      intervalRef.current = setInterval(action, intervalMs);
+    },
+    [clear, intervalMs]
+  );
+
+  /** 長押し終了（mouseup / mouseleave など） */
+  const onHoldEnd = clear;
+
+  return { onHoldStart, onHoldEnd };
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,11 +1,19 @@
+/**
+ * Next.js 設定
+ *
+ * Cloudflare Pages 向けに静的エクスポート（output: "export"）を使用します。
+ * ビルド成果物は out/ に出力されます。
+ */
+
+/** @type {import('next').NextConfig} */
 const nextConfig = {
-  /* config options here */
   output: "export",
   webpack: (config, { dev }) => {
     if (dev) {
+      // 一部環境（コンテナ等）でのファイル監視安定化
       config.watchOptions = {
-        aggregateTimeout: 1000, // 300ms の遅延を追加
-        poll: 1000, // 1秒ごとにファイルの変更をチェック
+        aggregateTimeout: 1000,
+        poll: 1000,
       };
     }
     return config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8",
-        "eslint-config-next": "15.0.3",
+        "eslint-config-next": "^14",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -277,13 +277,82 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.3.tgz",
-      "integrity": "sha512-3Ln/nHq2V+v8uIaxCR6YfYo7ceRgZNXfTd3yW1ukTaFbO+/I8jNakrjYWODvG9BuR2v5kgVtH/C8r0i11quOgw==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
+      "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fast-glob": "3.3.1"
+        "glob": "10.3.10"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -2214,25 +2283,25 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.3.tgz",
-      "integrity": "sha512-IGP2DdQQrgjcr4mwFPve4DrCqo7CVVez1WoYY47XwKSrYO4hC0Dlb+iJA60i0YfICOzgNADIb8r28BpQ5Zs0wg==",
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
+      "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.0.3",
-        "@rushstack/eslint-patch": "^1.10.3",
+        "@next/eslint-plugin-next": "14.2.35",
+        "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jsx-a11y": "^6.10.0",
-        "eslint-plugin-react": "^7.35.0",
-        "eslint-plugin-react-hooks": "^5.0.0"
+        "eslint-plugin-import": "^2.28.1",
+        "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-react": "^7.33.2",
+        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "eslint": "^7.23.0 || ^8.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
@@ -2488,16 +2557,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
-      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
+      "version": "5.0.0-canary-7118f5dd7-20230705",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
+      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -2641,36 +2710,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8",
-    "eslint-config-next": "15.0.3",
+    "eslint-config-next": "^14",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/utils/cardDefinitions.ts
+++ b/utils/cardDefinitions.ts
@@ -1,27 +1,41 @@
 /**
- * カード全体にかかわる定数をまとめる
- * カード個別の定数は、各カードのコンポーネント内に記述する
+ * カード全体で共有する定数・コンポーネント対応表・フォント定義
+ *
+ * カード個別の定数は、各コンポーネント内に記述してください。
  */
 
-import Dice from "../components/card/Dice";
-import Coin from "../components/card/Coin";
-import Roulette from "../components/card/Roulette";
-import OneOnOne from "../components/card/OneOnOne";
-import Timer from "../components/card/Timer";
-import Token from "../components/card/Token";
-import Score from "../components/card/Score";
-import Turn from "../components/card/Turn";
-import Winner from "../components/card/Winner";
-import PlayerSetting from "../components/card/PlayerSetting";
-import StyleSetting from "../components/card/StyleSetting";
-import Info from "../components/card/Info";
-import { CardComponent } from "./types";
-import { Shantell_Sans, Sansita_Swashed, Dancing_Script, Libre_Bodoni, Pixelify_Sans, Red_Hat_Text, Caveat, Stick_No_Bills, Tilt_Prism, Antonio } from 'next/font/google'
+import {
+  Shantell_Sans,
+  Sansita_Swashed,
+  Dancing_Script,
+  Libre_Bodoni,
+  Pixelify_Sans,
+  Red_Hat_Text,
+  Caveat,
+  Stick_No_Bills,
+  Tilt_Prism,
+  Antonio,
+} from "next/font/google";
 
-// カードコンポーネントとカード名の対応表
-export const cardMap: {
-  [key: string]: CardComponent;
-} = {
+import Dice from "@/components/card/Dice";
+import Coin from "@/components/card/Coin";
+import Roulette from "@/components/card/Roulette";
+import OneOnOne from "@/components/card/OneOnOne";
+import Timer from "@/components/card/Timer";
+import Token from "@/components/card/Token";
+import Score from "@/components/card/Score";
+import Turn from "@/components/card/Turn";
+import Winner from "@/components/card/Winner";
+import PlayerSetting from "@/components/card/PlayerSetting";
+import StyleSetting from "@/components/card/StyleSetting";
+import Info from "@/components/card/Info";
+import type { CardComponent, CardSetting, CardStyle, Player } from "./types";
+
+/**
+ * カード種別キーとコンポーネントの対応表
+ * Setter（空き枠の＋ボタン）は特殊コンポーネントのためここには含めません。
+ */
+export const cardMap: Record<string, CardComponent> = {
   dice: Dice,
   coin: Coin,
   roulette: Roulette,
@@ -34,17 +48,17 @@ export const cardMap: {
   playerSetting: PlayerSetting,
   styleSetting: StyleSetting,
   info: Info,
-
-  // setter は特殊なコンポーネントなので、ここでは設定しない
-  // setter: Setter,
 };
 
-// カードリストの最大サイズ
-export const maxRange = { rows: 20, cols: 20 };
+/** グリッドの最大サイズ（PC の仮想マス数） */
+export const maxRange = { rows: 20, cols: 20 } as const;
 
-// 初期カード
-// PC の場合は x,y で画面を構成、SP の場合は配列の順番で画面を構成
-export const initialCardsList = [
+/**
+ * 初期カード配置
+ * - PC: x / y でグリッド上の位置を決める
+ * - SP: 配列順がスワイプ順になる
+ */
+export const initialCardsList: CardSetting[] = [
   { component: "dice", x: 0, y: 1 },
   { component: "coin", x: 2, y: 0 },
   { component: "roulette", x: 2, y: 1 },
@@ -59,8 +73,8 @@ export const initialCardsList = [
   { component: "info", x: 2, y: 3 },
 ];
 
-// 初期スタイル
-export const initialStyle = {
+/** 初期スタイル（背景色・文字色・フォント番号） */
+export const initialStyle: CardStyle = {
   bgColor_1: "#432E54",
   bgColor_2: "#4B4376",
   fontColor_1: "#f0f6fc",
@@ -68,8 +82,8 @@ export const initialStyle = {
   fontStyle: 1,
 };
 
-// 初期プレイヤー
-export const initialPlayers = [
+/** 初期プレイヤー（ルーレット・ターン・勝利数などで共有） */
+export const initialPlayers: Player[] = [
   { name: "Player 1", color: "#aa11ff" },
   { name: "Player 2", color: "#5b97f9" },
   { name: "Player 3", color: "#11ff11" },
@@ -77,15 +91,29 @@ export const initialPlayers = [
   { name: "Player 5", color: "#a91111" },
 ];
 
-// フォントの設定
-const font_1 = Shantell_Sans({ subsets: ['latin'] });
-const font_2 = Sansita_Swashed({ subsets: ['latin'] });
-const font_3 = Dancing_Script({ subsets: ['latin'] });
-const font_4 = Libre_Bodoni({ subsets: ['latin'] });
-const font_5 = Pixelify_Sans({ subsets: ['latin'] });
-const font_6 = Red_Hat_Text({ subsets: ['latin'] });
-const font_7 = Caveat({ subsets: ['latin'] });
-const font_8 = Stick_No_Bills({ subsets: ['latin'] });
-const font_9 = Tilt_Prism({ subsets: ['latin'] });
-const font_10 = Antonio({ subsets: ['latin'] });
-export const fonts = [font_1, font_2, font_3, font_4, font_5, font_6, font_7, font_8, font_9, font_10];
+// ---------------------------------------------------------------------------
+// Google Fonts（StyleSetting で切り替え）
+// ---------------------------------------------------------------------------
+const font_1 = Shantell_Sans({ subsets: ["latin"] });
+const font_2 = Sansita_Swashed({ subsets: ["latin"] });
+const font_3 = Dancing_Script({ subsets: ["latin"] });
+const font_4 = Libre_Bodoni({ subsets: ["latin"] });
+const font_5 = Pixelify_Sans({ subsets: ["latin"] });
+const font_6 = Red_Hat_Text({ subsets: ["latin"] });
+const font_7 = Caveat({ subsets: ["latin"] });
+const font_8 = Stick_No_Bills({ subsets: ["latin"] });
+const font_9 = Tilt_Prism({ subsets: ["latin"] });
+const font_10 = Antonio({ subsets: ["latin"] });
+
+export const fonts = [
+  font_1,
+  font_2,
+  font_3,
+  font_4,
+  font_5,
+  font_6,
+  font_7,
+  font_8,
+  font_9,
+  font_10,
+];

--- a/utils/cardFuncs.ts
+++ b/utils/cardFuncs.ts
@@ -1,121 +1,143 @@
 /**
- * カード系で使用する関数をまとめる
+ * カード配置・ドラッグ＆ドロップ・グリッド計算まわりの関数群
  */
 
-import { Dispatch, SetStateAction } from "react";
+import { useCallback, type Dispatch, type SetStateAction } from "react";
+import type { CardSetting } from "./types";
+
+/** カード 1 枚の基準サイズ（Tailwind の w-56 / h-56 = 224px） */
+export const CARD_SIZE_PX = 224;
 
 /**
- * setInitialCardsList 関数
- * 初期カードリストを設定する関数
- * 
- * @param {{ component: string, x: number, y: number }[]} initialCardsList - 初期カードリスト
- * @param {number} maxRows - 最大行数
- * @param {number} maxCols - 最大列数
- * @returns {{ component: string, x: number, y: number }[]} 初期カードリスト
+ * 初期カードリストの空きマスを "setter" で埋める
+ *
+ * PC グリッドでは空き枠に＋ボタン（Setter）を置くため、
+ * 表示範囲内の全マスを埋めた配列を返します。
+ * 元配列は破壊しません（SP / PC で同じ initialCardsList を共有するため）。
+ *
+ * @param initialCardsList - 初期カード配置
+ * @param maxRows - 最大行数
+ * @param maxCols - 最大列数
+ * @returns setter で埋めたカードリスト
  */
-export const setInitialCardsList = (
-  initialCardsList: { component: string, x: number, y: number }[],
+export const fillEmptySlotsWithSetter = (
+  initialCardsList: CardSetting[],
   maxRows: number,
   maxCols: number
-): { component: string, x: number, y: number }[] => {
-  // 元配列を破壊しない（SP/PC で同じ initialCardsList を共有するため）
+): CardSetting[] => {
   const result = initialCardsList.map((card) => ({ ...card }));
+
   for (let y = 0; y < maxRows; y++) {
     for (let x = 0; x < maxCols; x++) {
-      const existingComponent = result.find(
-        (comp) => comp.x === x && comp.y === y
-      );
-      if (!existingComponent) {
+      const occupied = result.some((card) => card.x === x && card.y === y);
+      if (!occupied) {
         result.push({ component: "setter", x, y });
       }
     }
   }
+
   return result;
 };
 
+/** @deprecated fillEmptySlotsWithSetter を使用してください */
+export const setInitialCardsList = fillEmptySlotsWithSetter;
+
 /**
- * useDragDrop カスタムフック
- * ドラッグ＆ドロップの処理を管理するためのフック
- * 
- * @param {Dispatch<SetStateAction<number | null>>} setDragIndex - ドラッグ中のカードのインデックスを設定する関数
- * @param {Dispatch<SetStateAction<{ x: number; y: number } | null>>} setDragOffset - ドラッグ中のカードのオフセットを設定する関数
- * @param {number | null} dragIndex - ドラッグ中のカードのインデックス
- * @param {{ x: number; y: number } | null} dragOffset - ドラッグ中のカードのオフセット
- * @param {any[]} cardList - カードのリスト
- * @param {Dispatch<SetStateAction<any[]>>} setCardList - カードのリストを更新する関数
- * @returns {{ handleDragStart: (index: number, e: React.DragEvent<HTMLDivElement>) => void, handleDragOver: (e: React.DragEvent<HTMLDivElement>) => void, handleDrop: (e: React.DragEvent<HTMLDivElement>) => void }} ドラッグ＆ドロップのイベントハンドラを含むオブジェクト
+ * ドラッグ＆ドロップでカード位置を入れ替えるカスタムフック
+ *
+ * @param setDragIndex - ドラッグ中カードのインデックス
+ * @param setDragOffset - ドラッグ開始時のポインタ相対位置
+ * @param dragIndex - 現在ドラッグ中のインデックス
+ * @param dragOffset - 現在のオフセット
+ * @param cardList - カードリスト
+ * @param setCardList - カードリスト更新関数
  */
 export const useDragDrop = (
   setDragIndex: Dispatch<SetStateAction<number | null>>,
   setDragOffset: Dispatch<SetStateAction<{ x: number; y: number } | null>>,
   dragIndex: number | null,
   dragOffset: { x: number; y: number } | null,
-  cardList: any[],
-  setCardList: Dispatch<SetStateAction<any[]>>
+  cardList: CardSetting[],
+  setCardList: Dispatch<SetStateAction<CardSetting[]>>
 ) => {
-  const handleDragStart = (
-    index: number,
-    e: React.DragEvent<HTMLDivElement>
-  ) => {
-    setDragIndex(index);
-    const rect = e.currentTarget.getBoundingClientRect();
-    setDragOffset({ x: e.clientX - rect.left, y: e.clientY - rect.top });
-  };
+  const handleDragStart = useCallback(
+    (index: number, e: React.DragEvent<HTMLDivElement>) => {
+      setDragIndex(index);
+      const rect = e.currentTarget.getBoundingClientRect();
+      setDragOffset({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+    },
+    [setDragIndex, setDragOffset]
+  );
 
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
-  };
+  }, []);
 
-  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
-    if (dragIndex === null || dragOffset === null) return;
-    const cardSize = 224;
-    const newList = [...cardList];
-    const newX = Math.floor((e.clientX - dragOffset.x) / cardSize);
-    const newY = Math.floor((e.clientY - dragOffset.y) / cardSize);
-    if (newX >= 0 && newY >= 0) {
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (dragIndex === null || dragOffset === null) return;
+
+      const newList = [...cardList];
+      const newX = Math.floor((e.clientX - dragOffset.x) / CARD_SIZE_PX);
+      const newY = Math.floor((e.clientY - dragOffset.y) / CARD_SIZE_PX);
+
+      if (newX < 0 || newY < 0) {
+        setDragIndex(null);
+        setDragOffset(null);
+        return;
+      }
+
       const targetIndex = newList.findIndex(
         (item) => item.x === newX && item.y === newY
       );
+
       if (targetIndex !== -1) {
-        [newList[targetIndex], newList[dragIndex]] = [
-          { ...newList[dragIndex], x: newX, y: newY },
-          {
-            ...newList[targetIndex],
-            x: newList[dragIndex].x,
-            y: newList[dragIndex].y,
-          },
-        ];
+        // ドロップ先にカードがある場合は位置を入れ替える
+        const dragged = newList[dragIndex];
+        const target = newList[targetIndex];
+        newList[targetIndex] = { ...dragged, x: newX, y: newY };
+        newList[dragIndex] = { ...target, x: dragged.x, y: dragged.y };
       } else {
         newList[dragIndex] = { ...newList[dragIndex], x: newX, y: newY };
       }
+
       setCardList(newList);
-    }
-    setDragIndex(null);
-    setDragOffset(null);
-  };
+      setDragIndex(null);
+      setDragOffset(null);
+    },
+    [cardList, dragIndex, dragOffset, setCardList, setDragIndex, setDragOffset]
+  );
 
   return { handleDragStart, handleDragOver, handleDrop };
 };
 
 /**
- * calculateAndUpdateGrid 関数
- * ウィンドウの幅を基にカードの列数とズーム倍率を計算し、行数を返す関数
- * 
- * @param {number} outerWidth - ウィンドウの外幅
- * @param {number} innerWidth - ウィンドウの内幅
- * @returns {{ zoomRatio: number, cols: number, rows: number }} ズーム倍率、列数、行数を含むオブジェクト
+ * ウィンドウ幅からズーム倍率・列数・行数を計算する
+ *
+ * - 幅 500px 以下（SP）: 1 列、カード幅を画面幅に合わせる
+ * - それ以外（PC）: 横に収まる列数を計算し、余白に合わせてズーム
+ *
+ * @param outerWidth - window.outerWidth
+ * @param innerWidth - window.innerWidth
  */
-export const calculateAndUpdateGrid = (outerWidth: number, innerWidth: number) => {
-  const cardSize = 224; // 基本のカードの幅（w-56 h-56 の px 値）
+export const calculateAndUpdateGrid = (
+  outerWidth: number,
+  innerWidth: number
+): { zoomRatio: number; cols: number; rows: number } => {
   let zoomRatio = 1;
   let cols = 1;
-  // 幅が 500px 以下は列数を１にしてカード幅を画面幅に合わせる
+
   if (outerWidth <= 500) {
-    zoomRatio = outerWidth / cardSize;
+    zoomRatio = outerWidth / CARD_SIZE_PX;
   } else {
-    cols = Math.floor(innerWidth / cardSize);
-    zoomRatio = Math.min(innerWidth / (cols * cardSize));
+    cols = Math.floor(innerWidth / CARD_SIZE_PX);
+    zoomRatio = innerWidth / (cols * CARD_SIZE_PX);
   }
-  const rows = Math.floor(innerHeight / 224);
+
+  const rows = Math.floor(
+    (typeof window !== "undefined" ? window.innerHeight : CARD_SIZE_PX) /
+      CARD_SIZE_PX
+  );
+
   return { zoomRatio, cols, rows };
 };

--- a/utils/clamp.ts
+++ b/utils/clamp.ts
@@ -1,0 +1,18 @@
+/**
+ * 数値を指定範囲内に収めるユーティリティ
+ *
+ * Score / Token / Timer / Winner などで同じ上限・下限チェックが
+ * 重複していたため、共通関数として切り出しています。
+ */
+
+/**
+ * value を [min, max] の範囲にクランプする
+ * @param value - 対象の値
+ * @param min - 下限値
+ * @param max - 最大値
+ * @returns 範囲内に収めた値
+ */
+export function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}

--- a/utils/localFuncs.ts
+++ b/utils/localFuncs.ts
@@ -1,65 +1,52 @@
 /**
- * ローカルストレージの操作を行うためのユーティリティ関数を定義
+ * ローカルストレージの読み書きユーティリティ
+ *
+ * 設定（カード配置・スタイル・プレイヤー）をブラウザに永続化します。
+ * 本アプリは静的ホスト（Cloudflare Pages）前提のため、サーバー側の暗号化は行っていません。
+ * 保存内容は端末ローカルの UI 設定のみで、機密情報は扱いません。
  */
 
-// 目的は保存する値を取得されても安易に見られないようにするため暗号化を行っている
-// ただフロントでの処理の時点で程度は知れれている、本格的にセキュリティを考慮する場合はサーバーサイドで暗号化を行うべき
-const isEncryption = false; // 暗号化を行うかどうか
-const secretKey = "your-secret-key"; // 秘密鍵を設定
-
 /**
- * 簡単な暗号化関数
- * @param {string} value - 暗号化する値
- * @returns {string} - 暗号化された値
- */
-const encrypt = (value: string): string => {
-  const textToChars = (text: string) => text.split('').map(c => c.charCodeAt(0));
-  const byteHex = (n: number) => ("0" + Number(n).toString(16)).substring(-2);
-  const applySecretToChar = (code: number) => textToChars(secretKey).reduce((a, b) => a ^ b, code);
-  return value.split('')
-    .map(c => applySecretToChar(c.charCodeAt(0)))
-    .map(byteHex)
-    .join('');
-};
-
-/**
- * 簡単な復号化関数
- * @param {string} encrypted - 復号化する値
- * @returns {string} - 復号化された値
- */
-const decrypt = (encrypted: string): string => {
-  const textToChars = (text: string) => text.split('').map(c => c.charCodeAt(0));
-  const applySecretToChar = (code: number) => textToChars(secretKey).reduce((a, b) => a ^ b, code);
-  const match = encrypted.match(/.{1,2}/g);
-  if (!match) {
-    return '';
-  }
-  return match.map(hex => parseInt(hex, 16))
-    .map(applySecretToChar)
-    .map(charCode => String.fromCharCode(charCode))
-    .join('');
-};
-
-/**
- * ローカルストレージから値を取得する関数
- * @param {string} key - 取得するキー
- * @returns {string | null} - 値。存在しない場合はnullを返す
+ * ローカルストレージから文字列を取得する
+ * @param key - 取得するキー
+ * @returns 値。存在しない場合は null
  */
 export const getLocalStorage = (key: string): string | null => {
-  const encryptedValue = localStorage.getItem(key);
-  if (encryptedValue) {
-    return isEncryption ? decrypt(encryptedValue) : encryptedValue;
+  if (typeof window === "undefined") return null;
+  try {
+    return localStorage.getItem(key);
+  } catch (error) {
+    // Private Mode などで localStorage が使えない場合に備える
+    console.warn("localStorage の読み込みに失敗しました:", error);
+    return null;
   }
-  return null;
 };
 
 /**
- * ローカルストレージに値をセットする関数
- * @param {string} key - セットするキー
- * @param {string} value - セットする値
- * @returns {void}
+ * ローカルストレージに文字列を保存する
+ * @param key - セットするキー
+ * @param value - セットする値
  */
 export const setLocalStorage = (key: string, value: string): void => {
-  const encryptedValue = isEncryption ? encrypt(value) : value;
-  localStorage.setItem(key, encryptedValue);
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(key, value);
+  } catch (error) {
+    console.warn("localStorage の保存に失敗しました:", error);
+  }
+};
+
+/**
+ * ローカルストレージから JSON をパースして取得する
+ * パース失敗時は fallback を返す
+ */
+export const getLocalJson = <T>(key: string, fallback: T): T => {
+  const raw = getLocalStorage(key);
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn(`localStorage の JSON パースに失敗しました (${key}):`, error);
+    return fallback;
+  }
 };

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -1,36 +1,54 @@
 /**
- * カード全体にかかわる型をまとめる
- * カード個別の型は、各カードのコンポーネント内に記述する
+ * カード全体で共有する型定義
+ *
+ * カード個別の内部型は、各コンポーネント内に置いてください。
  */
 
-import React from "react";
+import type { ComponentType } from "react";
 
+/** プレイヤー情報（名前・表示色） */
 export type Player = {
   name: string;
   color: string;
 };
 
+/** グリッド上のカード配置情報 */
 export type CardSetting = {
+  /** cardMap のキー、または "setter"（空き枠） */
   component: string;
   x: number;
   y: number;
 };
 
+/** カード全体の見た目設定 */
 export type CardStyle = {
   bgColor_1: string;
   fontColor_1: string;
   bgColor_2: string;
   fontColor_2: string;
+  /** fonts 配列の 1 始まりインデックス */
   fontStyle: number;
 };
 
-export type CardComponent = React.ComponentType<{
+/**
+ * 各カードコンポーネントが受け取る共通 props
+ *
+ * Grid / GridSP から一括で渡されます。
+ * 使わない props があっても受け取り側で省略して問題ありません。
+ */
+export type CardProps = {
   zoomRatio: number;
   players: Player[];
-  setPlayers: (arg: Player[]) => void;
+  setPlayers: (players: Player[]) => void;
   cardStyle: CardStyle;
-  setCardStyle: (arg: CardStyle) => void;
-  setCardList: (arg: CardSetting[]) => void;
-  /** SP: 前後カードのみ true。非アクティブ時は重い Canvas を破棄する */
+  setCardStyle: (style: CardStyle) => void;
+  setCardList: (list: CardSetting[]) => void;
+  /**
+   * SP モード向け: 現在表示中のカードのみ true。
+   * 非アクティブ時は重い Canvas を破棄し、同時 WebGL コンテキスト数を抑えます。
+   */
   isActive?: boolean;
-}>;
+};
+
+/** cardMap に登録するコンポーネント型 */
+export type CardComponent = ComponentType<Partial<CardProps> & { zoomRatio?: number }>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要
古くなった実装を横断的に整理・モダン化し、README などの記述も読みやすく整えました。コメントは引き続き丁寧に残しています。

## 主な変更
- **共通化**: `clamp` / `useHoldRepeat` / `ResetButton` を追加し、各カウンター系カードの重複を削減
- **型・ユーティリティ**: `CardProps` の整理、`any` 削減、localStorage の安全な JSON 読み込み、セッター埋め関数名の明確化
- **バグ修正**: StyleSetting の `"use client"` 修正、Winner の render 中 `setState` 解消、PlayerSetting の破壊的更新の修正、Info の誤ったコンポーネント名修正
- **構成**: import を `@/` に統一、layout の Metadata / Viewport を Next の推奨形に、ボタン要素の semantic 化
- **README**: 目的・セットアップ・構成・デプロイを簡潔に再構成

## 動作確認
- `npm run lint`
- `npm run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e62bf3b-7377-479e-b60a-d6197de6809c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e62bf3b-7377-479e-b60a-d6197de6809c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

