### PR TITLE
ストップウォッチカードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 | Coin | 3D コイントス |
 | Roulette | プレイヤー色で分割するルーレット |
 | Timer | カウントダウンタイマー |
+| Stopwatch | ストップウォッチ（ラップ記録対応） |
 | Token / Score / OneOnOne | 各種カウンター |
 | Turn / Winner | ターン・勝利数管理 |
 | Player / Style | プレイヤー・見た目の設定 |

--- a/components/card/Stopwatch.tsx
+++ b/components/card/Stopwatch.tsx
@@ -65,22 +65,22 @@ export default function Stopwatch() {
   const canReset = !isRunning && (elapsedMs > 0 || laps.length > 0);
 
   return (
-    <div className="box-border h-full p-6 text-center">
-      <div className="inline-block w-40 bg-transparent text-3xl font-bold text-center outline-none tabular-nums">
+    <div className="box-border h-full py-6 text-center">
+      <div className="bg-transparent text-3xl font-bold tabular-nums">
         {formatTime(elapsedMs)}
       </div>
 
       <div className="flex justify-center items-center text-base">
         <button
           type="button"
-          className="px-2 py-1.5 text-lg cursor-pointer duration-200 hover:opacity-70"
+          className="px-3 py-1.5 text-lg cursor-pointer duration-200 hover:opacity-70"
           onClick={() => setIsRunning((prev) => !prev)}
         >
           {isRunning ? "STOP" : "START"}
         </button>
         <button
           type="button"
-          className={`px-2 py-1.5 text-lg duration-200${
+          className={`px-3 py-1.5 text-lg duration-200${
             canLap ? " cursor-pointer hover:opacity-70" : " opacity-70"
           }`}
           disabled={!canLap}
@@ -93,7 +93,7 @@ export default function Stopwatch() {
         </button>
         <button
           type="button"
-          className={`px-2 py-1.5 text-lg duration-200${
+          className={`px-3 py-1.5 text-lg duration-200${
             canReset ? " cursor-pointer hover:opacity-70" : " opacity-70"
           }`}
           disabled={!canReset}

--- a/components/card/Stopwatch.tsx
+++ b/components/card/Stopwatch.tsx
@@ -10,7 +10,7 @@
 import { useState, useEffect, useRef } from "react";
 
 const STOPWATCH_MAX_MS = 359999000; // 99:59:59.000
-const MAX_LAPS = 4;
+const MAX_LAPS = 3;
 
 function formatTime(ms: number): string {
   const clamped = Math.min(Math.max(ms, 0), STOPWATCH_MAX_MS);
@@ -65,22 +65,22 @@ export default function Stopwatch() {
   const canReset = !isRunning && (elapsedMs > 0 || laps.length > 0);
 
   return (
-    <div className="p-4 text-center">
-      <div className="inline-block w-48 bg-transparent text-3xl font-bold text-center outline-none tabular-nums">
+    <div className="box-border h-full p-6 text-center">
+      <div className="inline-block w-40 bg-transparent text-3xl font-bold text-center outline-none tabular-nums">
         {formatTime(elapsedMs)}
       </div>
 
       <div className="flex justify-center items-center text-base">
         <button
           type="button"
-          className="px-3 py-2 text-lg cursor-pointer duration-200 hover:opacity-70"
+          className="px-2 py-1.5 text-lg cursor-pointer duration-200 hover:opacity-70"
           onClick={() => setIsRunning((prev) => !prev)}
         >
           {isRunning ? "STOP" : "START"}
         </button>
         <button
           type="button"
-          className={`px-3 py-2 text-lg duration-200${
+          className={`px-2 py-1.5 text-lg duration-200${
             canLap ? " cursor-pointer hover:opacity-70" : " opacity-70"
           }`}
           disabled={!canLap}
@@ -93,7 +93,7 @@ export default function Stopwatch() {
         </button>
         <button
           type="button"
-          className={`px-3 py-2 text-lg duration-200${
+          className={`px-2 py-1.5 text-lg duration-200${
             canReset ? " cursor-pointer hover:opacity-70" : " opacity-70"
           }`}
           disabled={!canReset}
@@ -108,7 +108,7 @@ export default function Stopwatch() {
         </button>
       </div>
 
-      <div className="mt-1 h-20 overflow-hidden text-xs tabular-nums opacity-80">
+      <div className="mt-1 h-16 overflow-hidden text-xs tabular-nums opacity-80">
         {laps.length === 0 ? (
           <p className="opacity-50">LAP TIMES</p>
         ) : (

--- a/components/card/Stopwatch.tsx
+++ b/components/card/Stopwatch.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+/**
+ * ストップウォッチカード
+ *
+ * 経過時間の計測・ラップ記録に対応します。
+ * Timer（カウントダウン）の対になる計測ツールです。
+ */
+
+import { useState, useEffect, useRef } from "react";
+
+const STOPWATCH_MAX_MS = 359999000; // 99:59:59.000
+const MAX_LAPS = 4;
+
+function formatTime(ms: number): string {
+  const clamped = Math.min(Math.max(ms, 0), STOPWATCH_MAX_MS);
+  const totalSeconds = Math.floor(clamped / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const tenths = Math.floor((clamped % 1000) / 100);
+  return [
+    String(hours).padStart(2, "0"),
+    String(minutes).padStart(2, "0"),
+    String(seconds).padStart(2, "0"),
+  ].join(":") + `.${tenths}`;
+}
+
+export default function Stopwatch() {
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [isRunning, setIsRunning] = useState(false);
+  const [laps, setLaps] = useState<number[]>([]);
+  const accumulatedRef = useRef(0);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!isRunning) return;
+
+    const startedAt = Date.now();
+    const base = accumulatedRef.current;
+
+    tickRef.current = setInterval(() => {
+      const next = Math.min(base + (Date.now() - startedAt), STOPWATCH_MAX_MS);
+      setElapsedMs(next);
+      if (next >= STOPWATCH_MAX_MS) {
+        accumulatedRef.current = STOPWATCH_MAX_MS;
+        setIsRunning(false);
+      }
+    }, 50);
+
+    return () => {
+      if (tickRef.current) {
+        clearInterval(tickRef.current);
+        tickRef.current = null;
+      }
+      accumulatedRef.current = Math.min(
+        base + (Date.now() - startedAt),
+        STOPWATCH_MAX_MS
+      );
+      setElapsedMs(accumulatedRef.current);
+    };
+  }, [isRunning]);
+
+  const canLap = isRunning || elapsedMs > 0;
+  const canReset = !isRunning && (elapsedMs > 0 || laps.length > 0);
+
+  return (
+    <div className="p-4 text-center">
+      <div className="inline-block w-48 bg-transparent text-3xl font-bold text-center outline-none tabular-nums">
+        {formatTime(elapsedMs)}
+      </div>
+
+      <div className="flex justify-center items-center text-base">
+        <button
+          type="button"
+          className="px-3 py-2 text-lg cursor-pointer duration-200 hover:opacity-70"
+          onClick={() => setIsRunning((prev) => !prev)}
+        >
+          {isRunning ? "STOP" : "START"}
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-2 text-lg duration-200${
+            canLap ? " cursor-pointer hover:opacity-70" : " opacity-70"
+          }`}
+          disabled={!canLap}
+          onClick={() => {
+            if (!canLap) return;
+            setLaps((prev) => [elapsedMs, ...prev].slice(0, MAX_LAPS));
+          }}
+        >
+          LAP
+        </button>
+        <button
+          type="button"
+          className={`px-3 py-2 text-lg duration-200${
+            canReset ? " cursor-pointer hover:opacity-70" : " opacity-70"
+          }`}
+          disabled={!canReset}
+          onClick={() => {
+            if (!canReset) return;
+            accumulatedRef.current = 0;
+            setElapsedMs(0);
+            setLaps([]);
+          }}
+        >
+          RESET
+        </button>
+      </div>
+
+      <div className="mt-1 h-20 overflow-hidden text-xs tabular-nums opacity-80">
+        {laps.length === 0 ? (
+          <p className="opacity-50">LAP TIMES</p>
+        ) : (
+          <ul className="space-y-0.5">
+            {laps.map((lap, index) => (
+              <li key={`${lap}-${index}`}>
+                #{laps.length - index} {formatTime(lap)}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/utils/cardDefinitions.ts
+++ b/utils/cardDefinitions.ts
@@ -22,6 +22,7 @@ import Coin from "@/components/card/Coin";
 import Roulette from "@/components/card/Roulette";
 import OneOnOne from "@/components/card/OneOnOne";
 import Timer from "@/components/card/Timer";
+import Stopwatch from "@/components/card/Stopwatch";
 import Token from "@/components/card/Token";
 import Score from "@/components/card/Score";
 import Turn from "@/components/card/Turn";
@@ -41,6 +42,7 @@ export const cardMap: Record<string, CardComponent> = {
   roulette: Roulette,
   oneOnOne: OneOnOne,
   timer: Timer,
+  stopwatch: Stopwatch,
   token: Token,
   score: Score,
   turn: Turn,
@@ -64,6 +66,7 @@ export const initialCardsList: CardSetting[] = [
   { component: "roulette", x: 2, y: 1 },
   { component: "oneOnOne", x: 2, y: 2 },
   { component: "timer", x: 0, y: 2 },
+  { component: "stopwatch", x: 3, y: 2 },
   { component: "token", x: 1, y: 1 },
   { component: "score", x: 1, y: 2 },
   { component: "turn", x: 1, y: 0 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Timer（カウントダウン）の対になる **Stopwatch** カードを追加しました。
- START / STOP / RESET とラップ記録に対応しています。
- `cardMap` と初期配置、README の機能表にも登録済みです。
- 上下余白は維持しつつ、左右はパディングではなく中央揃えのみにしました（カウント表示の崩れを解消）。

## 使い方
- PC: グリッド上の Stopwatch、または空き枠の＋から追加
- SP: スワイプ一覧に含まれます（初期配置に追加）

## Test plan
- [ ] `npm run lint` / `npm run build` が通る
- [ ] START で経過時間が増える（0.1 秒単位表示）
- [ ] STOP で一時停止、再 START で続きから計測
- [ ] LAP でラップが記録される
- [ ] RESET で時間・ラップがクリアされる（計測中は無効）
- [ ] Setter から stopwatch を選べる
- [ ] カウント表示が左右中央に揃い、崩れない
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-672a3810-ff31-4488-bac7-229c4c56184b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-672a3810-ff31-4488-bac7-229c4c56184b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

